### PR TITLE
Update CI to test against Ruby 3.4 and 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.4"]
+        ruby: ["3.4", "4.0"]
         rails: ["8.0", "8.1"]
 
     env:
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
 
       - name: Check Ruby syntax


### PR DESCRIPTION
## Summary

- Update CI matrix from Ruby 3.3/3.4 to Ruby 3.4/4.0
- Bump minimum Ruby version to 3.4.0 in gemspec
- Update README requirements

## Test plan

- [ ] CI passes on Ruby 3.4
- [ ] CI passes on Ruby 4.0


🤖 Generated with [Claude Code](https://claude.com/claude-code)