### PR TITLE
Add support for multiple Coders

### DIFF
--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -42,8 +42,7 @@ module FixtureKit
 
       @data ||= file_cache.read
 
-      coders = configuration.coders.map(&:new)
-      coders.each do |coder|
+      configuration.coders.map(&:new).each do |coder|
         coder.mount(data.data_for(coder.class))
       end
 
@@ -52,19 +51,8 @@ module FixtureKit
 
     def save
       FixtureKit.runner.adapter.execute do |context|
-        coders = configuration.coders.map(&:new)
-
-        evaluate(coders) do
-          fixture.definition.evaluate(context, parent: fixture.parent&.mount)
-        end
-
-        data = coders.to_h do |coder|
-          parent_data = fixture.parent ? fixture.parent.cache.data.data_for(coder.class) : nil
-          [coder.class, coder.save(parent_data: parent_data)]
-        end
-
         @data = MemoryCache.new(
-          data: data,
+          data: evaluate(configuration.coders.map(&:new), context),
           exposed: file_cache.serialize_exposed(fixture.definition.exposed)
         )
       end
@@ -74,13 +62,19 @@ module FixtureKit
 
     private
 
-    def evaluate(coders, &block)
+    def evaluate(coders, context, memo = {}, &block)
       if coders.empty?
-        yield
+        fixture.definition.evaluate(context, parent: fixture.parent&.mount)
       else
         coder, *remaining_coders = coders
-        coder.observe { evaluate(remaining_coders, &block) }
+
+        parent_data = fixture.parent ? fixture.parent.cache.data.data_for(coder.class) : nil
+        memo[coder.class] = coder.save(parent_data: parent_data) do
+          evaluate(remaining_coders, context, memo, &block)
+        end
       end
+
+      memo
     end
 
     def file_cache

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -43,7 +43,7 @@ module FixtureKit
       @data ||= file_cache.read
 
       configuration.coders.map(&:new).each do |coder|
-        coder.mount(data.data_for(coder.class))
+        coder.load(data.data_for(coder.class))
       end
 
       Repository.new(data.exposed)

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -41,19 +41,30 @@ module FixtureKit
       end
 
       @data ||= file_cache.read
-      coder.mount(data.data_for(ActiveRecordCoder))
+
+      coders = configuration.coders.map(&:new)
+      coders.each do |coder|
+        coder.mount(data.data_for(coder.class))
+      end
 
       Repository.new(data.exposed)
     end
 
     def save
       FixtureKit.runner.adapter.execute do |context|
-        coder.observe do
+        coders = configuration.coders.map(&:new)
+
+        evaluate(coders) do
           fixture.definition.evaluate(context, parent: fixture.parent&.mount)
         end
 
+        data = coders.to_h do |coder|
+          parent_data = fixture.parent ? fixture.parent.cache.data.data_for(coder.class) : nil
+          [coder.class, coder.save(parent_data: parent_data)]
+        end
+
         @data = MemoryCache.new(
-          data: { ActiveRecordCoder => coder.save(parent_data: fixture.parent ? fixture.parent.cache.data_for(ActiveRecordCoder) : nil) },
+          data: data,
           exposed: file_cache.serialize_exposed(fixture.definition.exposed)
         )
       end
@@ -63,8 +74,13 @@ module FixtureKit
 
     private
 
-    def coder
-      @coder ||= ActiveRecordCoder.new
+    def evaluate(coders, &block)
+      if coders.empty?
+        yield
+      else
+        coder, *remaining_coders = coders
+        coder.observe { evaluate(remaining_coders, &block) }
+      end
     end
 
     def file_cache

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -41,7 +41,7 @@ module FixtureKit
       end
 
       @data ||= file_cache.read
-      coder.mount(data.records)
+      coder.mount(data.data_for(ActiveRecordCoder))
 
       Repository.new(data.exposed)
     end
@@ -53,7 +53,7 @@ module FixtureKit
         end
 
         @data = MemoryCache.new(
-          records: coder.save(parent_data: fixture.parent ? fixture.parent.cache.data.records : nil),
+          data: { ActiveRecordCoder => coder.save(parent_data: fixture.parent ? fixture.parent.cache.data_for(ActiveRecordCoder) : nil) },
           exposed: file_cache.serialize_exposed(fixture.definition.exposed)
         )
       end

--- a/lib/fixture_kit/coder.rb
+++ b/lib/fixture_kit/coder.rb
@@ -2,11 +2,7 @@
 
 module FixtureKit
   class Coder
-    def observe(&block)
-      yield
-    end
-
-    def save(parent_data: nil)
+    def save(parent_data: nil, &block)
       raise NotImplementedError, "#{self.class} must implement #save"
     end
 

--- a/lib/fixture_kit/coder.rb
+++ b/lib/fixture_kit/coder.rb
@@ -9,5 +9,13 @@ module FixtureKit
     def load(data)
       raise NotImplementedError, "#{self.class} must implement #load"
     end
+
+    def encode(data)
+      data
+    end
+
+    def decode(data)
+      data
+    end
   end
 end

--- a/lib/fixture_kit/coder.rb
+++ b/lib/fixture_kit/coder.rb
@@ -6,8 +6,8 @@ module FixtureKit
       raise NotImplementedError, "#{self.class} must implement #save"
     end
 
-    def mount(data)
-      raise NotImplementedError, "#{self.class} must implement #mount"
+    def load(data)
+      raise NotImplementedError, "#{self.class} must implement #load"
     end
   end
 end

--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -26,7 +26,7 @@ module FixtureKit
       generate_statements(captured_models)
     end
 
-    def mount(data)
+    def load(data)
       statements_by_connection(data).each do |connection, statements|
         connection.disable_referential_integrity do
           # execute_batch is private in current supported Rails versions.

--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -36,6 +36,12 @@ module FixtureKit
       end
     end
 
+    def decode(data)
+      data.transform_keys do |model_name|
+        ActiveSupport::Inflector.constantize(model_name)
+      end
+    end
+
     private
 
     def base_table_model(model)

--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -8,30 +8,22 @@ module FixtureKit
     EVENT = "sql.active_record"
     NAME_PATTERN = /\A(?<model_name>.+?) (?:(?:Bulk )?(?:Insert|Upsert)|Create|Destroy|(?:Update|Delete)(?: All)?)\z/
 
-    def initialize
-      @captured_models = Set.new
-    end
-
-    def observe(&block)
+    def save(parent_data: nil, &block)
+      captured_models = Set.new
       subscriber = lambda do |_event_name, _start, _finish, _id, payload|
         name = payload[:name].to_s
         model_name = name[NAME_PATTERN, :model_name]
         next unless model_name
 
-        @captured_models.add(ActiveSupport::Inflector.constantize(model_name))
+        captured_models.add(ActiveSupport::Inflector.constantize(model_name))
       end
 
       ActiveSupport::Notifications.subscribed(subscriber, EVENT, monotonic: true, &block)
 
-      @captured_models.map! { |model| base_table_model(model) }
-    end
+      captured_models.map! { |model| base_table_model(model) }
+      captured_models.merge(parent_data.keys) if parent_data
 
-    def save(parent_data: nil)
-      if parent_data
-        generate_statements(@captured_models + parent_data.keys)
-      else
-        generate_statements(@captured_models)
-      end
+      generate_statements(captured_models)
     end
 
     def mount(data)

--- a/lib/fixture_kit/configuration.rb
+++ b/lib/fixture_kit/configuration.rb
@@ -4,7 +4,7 @@ module FixtureKit
   class Configuration
     attr_accessor :fixture_path
     attr_accessor :cache_path
-    attr_reader :adapter_options, :callbacks
+    attr_reader :adapter_options, :callbacks, :coders
 
     def initialize
       @fixture_path = "fixture_kit"
@@ -12,6 +12,11 @@ module FixtureKit
       @adapter_class = FixtureKit::MinitestAdapter
       @adapter_options = {}
       @callbacks = Callbacks.new
+      @coders = Set.new([FixtureKit::ActiveRecordCoder])
+    end
+
+    def register_coder(coder)
+      @coders.add(coder)
     end
 
     def adapter(adapter_class = nil, **options)

--- a/lib/fixture_kit/configuration.rb
+++ b/lib/fixture_kit/configuration.rb
@@ -15,7 +15,7 @@ module FixtureKit
       @coders = Set.new([ActiveRecordCoder])
     end
 
-    def register_coder(coder)
+    def register(coder)
       @coders.add(coder)
     end
 

--- a/lib/fixture_kit/configuration.rb
+++ b/lib/fixture_kit/configuration.rb
@@ -9,10 +9,10 @@ module FixtureKit
     def initialize
       @fixture_path = "fixture_kit"
       @cache_path = "tmp/cache/fixture_kit"
-      @adapter_class = FixtureKit::MinitestAdapter
+      @adapter_class = MinitestAdapter
       @adapter_options = {}
       @callbacks = Callbacks.new
-      @coders = Set.new([FixtureKit::ActiveRecordCoder])
+      @coders = Set.new([ActiveRecordCoder])
     end
 
     def register_coder(coder)

--- a/lib/fixture_kit/file_cache.rb
+++ b/lib/fixture_kit/file_cache.rb
@@ -18,8 +18,10 @@ module FixtureKit
 
     def read
       file_data = JSON.parse(File.read(path))
-      records = file_data.fetch("records").transform_keys do |model_name|
-        ActiveSupport::Inflector.constantize(model_name)
+
+      data = file_data.fetch("data").each_with_object({}) do |(coder_name, coder_data), hash|
+        coder_class = ActiveSupport::Inflector.constantize(coder_name)
+        hash[coder_class] = deserialize_coder_data(coder_class, coder_data)
       end
 
       exposed = file_data.fetch("exposed").each_with_object({}) do |(name, value), hash|
@@ -30,7 +32,7 @@ module FixtureKit
         end
       end
 
-      MemoryCache.new(records: records, exposed: exposed)
+      MemoryCache.new(data: data, exposed: exposed)
     end
 
     def write(data)
@@ -45,6 +47,19 @@ module FixtureKit
         else
           hash[name] = { record.class => record.id }
         end
+      end
+    end
+
+    private
+
+    def deserialize_coder_data(coder_class, coder_data)
+      case coder_class
+      when FixtureKit::ActiveRecordCoder.singleton_class
+        coder_data.transform_keys do |model_name|
+          ActiveSupport::Inflector.constantize(model_name)
+        end
+      else
+        coder_data
       end
     end
   end

--- a/lib/fixture_kit/file_cache.rb
+++ b/lib/fixture_kit/file_cache.rb
@@ -21,7 +21,7 @@ module FixtureKit
 
       data = file_data.fetch("data").each_with_object({}) do |(coder_name, coder_data), hash|
         coder_class = ActiveSupport::Inflector.constantize(coder_name)
-        hash[coder_class] = deserialize_coder_data(coder_class, coder_data)
+        hash[coder_class] = coder_class.new.decode(coder_data)
       end
 
       exposed = file_data.fetch("exposed").each_with_object({}) do |(name, value), hash|
@@ -36,8 +36,15 @@ module FixtureKit
     end
 
     def write(data)
+      file_data = {
+        data: data.data.to_h do |coder_class, coder_data|
+          [coder_class, coder_class.new.encode(coder_data)]
+        end,
+        exposed: data.exposed,
+      }
+
       FileUtils.mkdir_p(File.dirname(path))
-      File.write(path, JSON.pretty_generate(data.to_h))
+      File.write(path, JSON.pretty_generate(file_data))
     end
 
     def serialize_exposed(exposed)
@@ -47,19 +54,6 @@ module FixtureKit
         else
           hash[name] = { record.class => record.id }
         end
-      end
-    end
-
-    private
-
-    def deserialize_coder_data(coder_class, coder_data)
-      case coder_class
-      when FixtureKit::ActiveRecordCoder.singleton_class
-        coder_data.transform_keys do |model_name|
-          ActiveSupport::Inflector.constantize(model_name)
-        end
-      else
-        coder_data
       end
     end
   end

--- a/lib/fixture_kit/memory_cache.rb
+++ b/lib/fixture_kit/memory_cache.rb
@@ -2,16 +2,20 @@
 
 module FixtureKit
   class MemoryCache
-    attr_reader :records, :exposed
+    attr_reader :data, :exposed
 
-    def initialize(records:, exposed:)
-      @records = records
+    def initialize(data:, exposed:)
+      @data = data
       @exposed = exposed
       freeze
     end
 
+    def data_for(coder_class)
+      data.fetch(coder_class)
+    end
+
     def to_h
-      { records: records, exposed: exposed }
+      { data: data, exposed: exposed }
     end
   end
 end

--- a/lib/fixture_kit/memory_cache.rb
+++ b/lib/fixture_kit/memory_cache.rb
@@ -13,9 +13,5 @@ module FixtureKit
     def data_for(coder_class)
       data.fetch(coder_class)
     end
-
-    def to_h
-      { data: data, exposed: exposed }
-    end
   end
 end

--- a/spec/dummy/spec/integration/fixture_kit_integration.rb
+++ b/spec/dummy/spec/integration/fixture_kit_integration.rb
@@ -103,7 +103,7 @@ RSpec.describe "FixtureKit integration" do
       cache_file = File.join(FixtureKit.runner.configuration.cache_path, "query_type_events.json")
       cache_data = JSON.parse(File.read(cache_file))
 
-      expect(cache_data.fetch("records").keys).to include("User", "Project", "Task", "Comment", "ActivityLog")
+      expect(cache_data.fetch("data").fetch("FixtureKit::ActiveRecordCoder").keys).to include("User", "Project", "Task", "Comment", "ActivityLog")
       puts "FKIT_ASSERT:QUERY_TYPES_CAPTURED"
     end
   end

--- a/spec/dummy/test/integration/fixture_kit_integration_test.rb
+++ b/spec/dummy/test/integration/fixture_kit_integration_test.rb
@@ -77,11 +77,11 @@ class FixtureKitQueryEventCoverageIntegrationTest < ActiveSupport::TestCase
     cache_file = File.join(FixtureKit.runner.configuration.cache_path, "query_type_events.json")
     cache_data = JSON.parse(File.read(cache_file))
 
-    assert_includes cache_data.fetch("records").keys, "User"
-    assert_includes cache_data.fetch("records").keys, "Project"
-    assert_includes cache_data.fetch("records").keys, "Task"
-    assert_includes cache_data.fetch("records").keys, "Comment"
-    assert_includes cache_data.fetch("records").keys, "ActivityLog"
+    assert_includes cache_data.fetch("data").fetch("FixtureKit::ActiveRecordCoder").keys, "User"
+    assert_includes cache_data.fetch("data").fetch("FixtureKit::ActiveRecordCoder").keys, "Project"
+    assert_includes cache_data.fetch("data").fetch("FixtureKit::ActiveRecordCoder").keys, "Task"
+    assert_includes cache_data.fetch("data").fetch("FixtureKit::ActiveRecordCoder").keys, "Comment"
+    assert_includes cache_data.fetch("data").fetch("FixtureKit::ActiveRecordCoder").keys, "ActivityLog"
     puts "FKIT_ASSERT:QUERY_TYPES_CAPTURED"
   end
 end

--- a/spec/support/dummy_rails_helper.rb
+++ b/spec/support/dummy_rails_helper.rb
@@ -54,6 +54,7 @@ def setup_databases
     t.string :name, null: false
     t.text :description
     t.string :status, default: "active"
+    t.datetime :deleted_at
     t.references :owner, null: false, foreign_key: { to_table: :users }
     t.timestamps
   end

--- a/spec/unit/coders/active_record_coder_spec.rb
+++ b/spec/unit/coders/active_record_coder_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     end
   end
 
-  describe "#mount" do
+  describe "#load" do
     it "documents that connection execute_batch is currently private" do
       connection = User.connection
 
@@ -144,7 +144,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
       expect(analytics_connection).to receive(:disable_referential_integrity).once.and_yield
       expect(analytics_connection).to receive(:execute_batch).with(analytics_statements, "FixtureKit Load").once
 
-      coder.mount(records)
+      coder.load(records)
     end
   end
 

--- a/spec/unit/coders/active_record_coder_spec.rb
+++ b/spec/unit/coders/active_record_coder_spec.rb
@@ -36,77 +36,71 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     destroyed.destroy!
   end
 
-  describe "#observe" do
+  describe "#save" do
     it "captures user model writes for all supported write operation types" do
       suffix = SecureRandom.hex(6)
 
-      coder.observe { exercise_user_write_operations(suffix) }
+      result = coder.save { exercise_user_write_operations(suffix) }
 
-      expect(coder.save).to have_key(User)
+      expect(result).to have_key(User)
     end
 
     it "resolves STI subclasses to their base table-owning model" do
-      coder.observe do
+      result = coder.save do
         Car.create!(name: "Sedan", year: 2024)
         Truck.create!(name: "Pickup", year: 2023)
       end
 
-      expect(coder.save.keys).to contain_exactly(Vehicle)
+      expect(result.keys).to contain_exactly(Vehicle)
     end
 
     it "resolves STI subclasses whose base model inherits directly from ActiveRecord::Base" do
-      coder.observe do
+      result = coder.save do
         Phone.create!(name: "iPhone")
         Tablet.create!(name: "iPad")
       end
 
-      expect(coder.save.keys).to contain_exactly(Gadget)
+      expect(result.keys).to contain_exactly(Gadget)
     end
 
     it "captures models written with update operations" do
       user = User.create!(name: "Alice", email: "alice-update@example.com")
 
-      coder.observe do
-        User.find(user.id).update!(name: "Alice Updated")
-      end
+      result = coder.save { User.find(user.id).update!(name: "Alice Updated") }
 
-      expect(coder.save).to have_key(User)
+      expect(result).to have_key(User)
     end
 
     it "captures models written with delete and destroy operations" do
       User.create!(name: "Alice", email: "alice-delete@example.com")
       doomed = User.create!(name: "Bob", email: "bob-delete@example.com")
 
-      coder.observe { doomed.destroy! }
+      result = coder.save { doomed.destroy! }
 
-      expect(coder.save).to have_key(User)
+      expect(result).to have_key(User)
     end
-  end
 
-  describe "#save" do
     it "generates INSERT statements for captured models" do
       User.create!(name: "Alice", email: "alice-save@example.com")
 
-      coder.observe { User.create!(name: "Bob", email: "bob-save@example.com") }
+      result = coder.save { User.create!(name: "Bob", email: "bob-save@example.com") }
 
-      result = coder.save
       expect(result[User]).to match(/INSERT INTO/)
     end
 
     it "stores nil sql for a model when its table is empty after changes" do
       user = User.create!(name: "Alice", email: "alice-empty@example.com")
 
-      coder.observe { user.destroy! }
-
-      expect(coder.save[User]).to be_nil
+      expect(coder.save { user.destroy! }[User]).to be_nil
     end
 
     it "includes models from parent_data that were not directly captured" do
       User.create!(name: "Alice", email: "alice-parent@example.com")
-      coder.observe { Project.create!(name: "Project", owner: User.find_by!(email: "alice-parent@example.com")) }
 
       parent_data = { User => "INSERT INTO users ..." }
-      result = coder.save(parent_data: parent_data)
+      result = coder.save(parent_data: parent_data) do
+        Project.create!(name: "Project", owner: User.find_by!(email: "alice-parent@example.com"))
+      end
 
       expect(result.keys).to include(User, Project)
     end

--- a/spec/unit/file_cache_spec.rb
+++ b/spec/unit/file_cache_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe FixtureKit::FileCache do
   describe "#write and #read" do
     it "round-trips MemoryCache through JSON on disk" do
       data = FixtureKit::MemoryCache.new(
-        records: { User => "INSERT INTO users (id, name) VALUES (1, 'Alice')" },
+        data: { FixtureKit::ActiveRecordCoder => { User => "INSERT INTO users (id, name) VALUES (1, 'Alice')" } },
         exposed: { alice: { User => 1 } }
       )
 
@@ -46,25 +46,25 @@ RSpec.describe FixtureKit::FileCache do
       expect(File.exist?(file_path)).to be(true)
       result = file_cache.read
       expect(result).to be_a(FixtureKit::MemoryCache)
-      expect(result.records).to eq({ User => "INSERT INTO users (id, name) VALUES (1, 'Alice')" })
+      expect(result.data[FixtureKit::ActiveRecordCoder]).to eq({ User => "INSERT INTO users (id, name) VALUES (1, 'Alice')" })
       expect(result.exposed).to eq({ alice: { User => 1 } })
     end
 
     it "round-trips MemoryCache with nil sql values" do
       data = FixtureKit::MemoryCache.new(
-        records: { User => nil },
+        data: { FixtureKit::ActiveRecordCoder => { User => nil } },
         exposed: {}
       )
 
       file_cache.write(data)
       result = file_cache.read
 
-      expect(result.records).to eq({ User => nil })
+      expect(result.data[FixtureKit::ActiveRecordCoder]).to eq({ User => nil })
     end
 
     it "round-trips MemoryCache with array exposed values" do
       data = FixtureKit::MemoryCache.new(
-        records: {},
+        data: { FixtureKit::ActiveRecordCoder => {} },
         exposed: { users: [{ User => 1 }, { User => 2 }] }
       )
 
@@ -77,7 +77,7 @@ RSpec.describe FixtureKit::FileCache do
     it "creates intermediate directories" do
       nested_path = File.join(cache_path, "nested", "deep", "fixture.json")
       nested_file_cache = described_class.new(nested_path)
-      data = FixtureKit::MemoryCache.new(records: {}, exposed: {})
+      data = FixtureKit::MemoryCache.new(data: {}, exposed: {})
 
       nested_file_cache.write(data)
 

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -396,7 +396,8 @@ RSpec.describe FixtureKit::Cache do
   describe "with a secondary coder" do
     let(:secondary_coder) do
       klass = Class.new(FixtureKit::Coder) do
-        def save(parent_data: nil)
+        def save(parent_data: nil, &block)
+          yield
           { "key" => "value" }
         end
 

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe FixtureKit::Cache do
       path = fixture_cache.path
       expect(File.exist?(path)).to be(true)
       data = JSON.parse(File.read(path))
-      expect(data["records"]).to have_key("User")
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"]).to have_key("User")
       expect(data["exposed"]).to have_key("alice")
     end
 
@@ -167,7 +167,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
 
       data = JSON.parse(File.read(fixture_cache.path))
-      expect(data["records"]).to have_key("User")
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"]).to have_key("User")
 
       User.delete_all
       repository = fixture_cache.load
@@ -194,7 +194,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
 
       data = JSON.parse(File.read(fixture_cache.path))
-      expect(data["records"]).to have_key("User")
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"]).to have_key("User")
 
       User.delete_all
       repository = fixture_cache.load
@@ -219,7 +219,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
 
       data = JSON.parse(File.read(fixture_cache.path))
-      expect(data["records"]["User"]).to be_nil
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"]["User"]).to be_nil
 
       User.create!(name: "Temporary", email: "temporary@example.com")
       fixture_cache.load
@@ -228,7 +228,7 @@ RSpec.describe FixtureKit::Cache do
 
     it "includes parent fixture model records when saving inherited fixtures" do
       parent_cache_data = FixtureKit::MemoryCache.new(
-        records: { User => nil },
+        data: { FixtureKit::ActiveRecordCoder => { User => nil } },
         exposed: {}
       )
       parent_cache = instance_double(FixtureKit::Cache, data: parent_cache_data)
@@ -254,13 +254,13 @@ RSpec.describe FixtureKit::Cache do
       child_cache.save
 
       data = JSON.parse(File.read(child_cache.path))
-      expect(data["records"].keys).to include("User", "Project")
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"].keys).to include("User", "Project")
     end
   end
 
   describe "#clear_memory" do
     it "nils out @data" do
-      cache.instance_variable_set(:@data, FixtureKit::MemoryCache.new(records: {}, exposed: {}))
+      cache.instance_variable_set(:@data, FixtureKit::MemoryCache.new(data: {}, exposed: {}))
 
       cache.clear_memory
 
@@ -331,10 +331,12 @@ RSpec.describe FixtureKit::Cache do
       cache.instance_variable_set(
         :@data,
         FixtureKit::MemoryCache.new(
-          records: {
-            User => user_sql,
-            Project => project_sql,
-            ActivityLog => activity_log_sql
+          data: {
+            FixtureKit::ActiveRecordCoder => {
+              User => user_sql,
+              Project => project_sql,
+              ActivityLog => activity_log_sql
+            }
           },
           exposed: {}
         )

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -442,7 +442,70 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
       fixture_cache.clear_memory
 
-      expect { fixture_cache.load }.not_to raise_error
+      expect_any_instance_of(FixtureKit::SecondaryCoder).to receive(:load).with({ "key" => "value" }).and_call_original
+      fixture_cache.load
+    end
+  end
+
+  describe "with a secondary coder that defines custom encode/decode" do
+    let(:secondary_coder) do
+      klass = Class.new(FixtureKit::Coder) do
+        def save(parent_data: nil, &block)
+          yield if block_given?
+          { "raw" => "value" }
+        end
+
+        def load(data)
+        end
+
+        def encode(data)
+          { "encoded" => true, "payload" => data }
+        end
+
+        def decode(data)
+          data.fetch("payload")
+        end
+      end
+      stub_const("FixtureKit::EncodingCoder", klass)
+    end
+
+    before do
+      runner.configuration.register(secondary_coder)
+    end
+
+    it "writes encoded data to disk" do
+      fixture_definition = FixtureKit::Definition.new do
+        alice = User.create!(name: "Alice", email: "alice-cache@example.com")
+        expose(alice: alice)
+      end
+      fixture_double = instance_double(
+        FixtureKit::Fixture,
+        identifier: fixture_name,
+        definition: fixture_definition,
+        parent: nil
+      )
+      fixture_cache = described_class.new(fixture_double)
+      fixture_cache.save
+
+      data = JSON.parse(File.read(fixture_cache.path))
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"].keys).to include("User")
+      expect(data["data"]["FixtureKit::EncodingCoder"]).to eq({ "encoded" => true, "payload" => { "raw" => "value" } })
+    end
+
+    it "passes decoded data to load after a round-trip through disk" do
+      fixture_definition = FixtureKit::Definition.new {}
+      fixture_double = instance_double(
+        FixtureKit::Fixture,
+        identifier: fixture_name,
+        definition: fixture_definition,
+        parent: nil
+      )
+      fixture_cache = described_class.new(fixture_double)
+      fixture_cache.save
+      fixture_cache.clear_memory
+
+      expect_any_instance_of(FixtureKit::EncodingCoder).to receive(:load).with({ "raw" => "value" }).and_call_original
+      fixture_cache.load
     end
   end
 end

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe FixtureKit::Cache do
           { "key" => "value" }
         end
 
-        def mount(data)
+        def load(data)
         end
       end
       stub_const("FixtureKit::SecondaryCoder", klass)

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -393,4 +393,55 @@ RSpec.describe FixtureKit::Cache do
 
   end
 
+  describe "with a secondary coder" do
+    let(:secondary_coder) do
+      klass = Class.new(FixtureKit::Coder) do
+        def save(parent_data: nil)
+          { "key" => "value" }
+        end
+
+        def mount(data)
+        end
+      end
+      stub_const("FixtureKit::SecondaryCoder", klass)
+    end
+
+    before do
+      runner.configuration.register_coder(secondary_coder)
+    end
+
+    it "saves secondary coder data to disk" do
+      fixture_definition = FixtureKit::Definition.new do
+        alice = User.create!(name: "Alice", email: "alice-cache@example.com")
+        expose(alice: alice)
+      end
+      fixture_double = instance_double(
+        FixtureKit::Fixture,
+        identifier: fixture_name,
+        definition: fixture_definition,
+        parent: nil
+      )
+      fixture_cache = described_class.new(fixture_double)
+      fixture_cache.save
+
+      data = JSON.parse(File.read(fixture_cache.path))
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"].keys).to include("User")
+      expect(data["data"]["FixtureKit::SecondaryCoder"]).to eq({ "key" => "value" })
+    end
+
+    it "loads secondary coder data from disk" do
+      fixture_definition = FixtureKit::Definition.new {}
+      fixture_double = instance_double(
+        FixtureKit::Fixture,
+        identifier: fixture_name,
+        definition: fixture_definition,
+        parent: nil
+      )
+      fixture_cache = described_class.new(fixture_double)
+      fixture_cache.save
+      fixture_cache.clear_memory
+
+      expect { fixture_cache.load }.not_to raise_error
+    end
+  end
 end

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe FixtureKit::Cache do
     end
 
     before do
-      runner.configuration.register_coder(secondary_coder)
+      runner.configuration.register(secondary_coder)
     end
 
     it "saves secondary coder data to disk" do

--- a/spec/unit/memory_cache_spec.rb
+++ b/spec/unit/memory_cache_spec.rb
@@ -4,29 +4,32 @@ require "spec_helper"
 
 RSpec.describe FixtureKit::MemoryCache do
   describe "#initialize" do
-    it "stores records and exposed data" do
-      cache = described_class.new(records: { "User" => "SQL" }, exposed: { alice: 1 })
+    it "stores data and exposed" do
+      cache = described_class.new(
+        data: { FixtureKit::ActiveRecordCoder => { "User" => "SQL" } },
+        exposed: { alice: 1 }
+      )
 
-      expect(cache.records).to eq({ "User" => "SQL" })
+      expect(cache.data).to eq({ FixtureKit::ActiveRecordCoder => { "User" => "SQL" } })
       expect(cache.exposed).to eq({ alice: 1 })
     end
 
     it "is frozen after initialization" do
-      cache = described_class.new(records: {}, exposed: {})
+      cache = described_class.new(data: {}, exposed: {})
 
       expect(cache).to be_frozen
     end
   end
 
   describe "#to_h" do
-    it "returns a hash of records and exposed" do
+    it "returns a hash of data and exposed" do
       cache = described_class.new(
-        records: { "User" => "INSERT INTO users VALUES (1)" },
+        data: { FixtureKit::ActiveRecordCoder => { "User" => "INSERT INTO users VALUES (1)" } },
         exposed: { alice: { "User" => 1 } }
       )
 
       expect(cache.to_h).to eq({
-        records: { "User" => "INSERT INTO users VALUES (1)" },
+        data: { FixtureKit::ActiveRecordCoder => { "User" => "INSERT INTO users VALUES (1)" } },
         exposed: { alice: { "User" => 1 } }
       })
     end

--- a/spec/unit/memory_cache_spec.rb
+++ b/spec/unit/memory_cache_spec.rb
@@ -20,18 +20,4 @@ RSpec.describe FixtureKit::MemoryCache do
       expect(cache).to be_frozen
     end
   end
-
-  describe "#to_h" do
-    it "returns a hash of data and exposed" do
-      cache = described_class.new(
-        data: { FixtureKit::ActiveRecordCoder => { "User" => "INSERT INTO users VALUES (1)" } },
-        exposed: { alice: { "User" => 1 } }
-      )
-
-      expect(cache.to_h).to eq({
-        data: { FixtureKit::ActiveRecordCoder => { "User" => "INSERT INTO users VALUES (1)" } },
-        exposed: { alice: { "User" => 1 } }
-      })
-    end
-  end
 end


### PR DESCRIPTION
## Summary

- Generalizes the cache data shape to support multiple coders, not just `ActiveRecordCoder`
- Adds a `coders` registry to `Configuration` so additional coders can be registered alongside the default
- Ensures all coders observe fixture evaluation simultaneously, regardless of how many are registered

## Test plan

- [x] Existing fixture cache specs pass with updated data shape
- [x] Secondary coder integration test: saves and loads custom coder data alongside `ActiveRecordCoder`
- [x] File cache round-trip specs updated for new `data:` shape
- [x] Memory cache specs updated for new shape and `data_for` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)