### PR TITLE
Only instantiate coders once

### DIFF
--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -42,7 +42,7 @@ module FixtureKit
 
       @data ||= file_cache.read
 
-      configuration.coders.map(&:new).each do |coder|
+      FixtureKit.runner.coders.each do |coder|
         coder.load(data.data_for(coder.class))
       end
 
@@ -52,7 +52,7 @@ module FixtureKit
     def save
       FixtureKit.runner.adapter.execute do |context|
         @data = MemoryCache.new(
-          data: evaluate(configuration.coders.map(&:new), context),
+          data: evaluate(FixtureKit.runner.coders, context),
           exposed: file_cache.serialize_exposed(fixture.definition.exposed)
         )
       end

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -6,7 +6,7 @@ module FixtureKit
 
     include ConfigurationHelper
 
-    attr_reader :fixture, :data
+    attr_reader :fixture, :content
 
     def initialize(fixture)
       @fixture = fixture
@@ -28,11 +28,11 @@ module FixtureKit
     end
 
     def exists?
-      data || file_cache.exists?
+      content || file_cache.exists?
     end
 
     def clear_memory
-      @data = nil
+      @content = nil
     end
 
     def load
@@ -40,41 +40,41 @@ module FixtureKit
         raise FixtureKit::CacheMissingError, "Cache does not exist for fixture '#{fixture.identifier}'"
       end
 
-      @data ||= file_cache.read
+      @content ||= file_cache.read
 
       FixtureKit.runner.coders.each do |coder|
-        coder.load(data.data_for(coder.class))
+        coder.load(content.data_for(coder.class))
       end
 
-      Repository.new(data.exposed)
+      Repository.new(content.exposed)
     end
 
     def save
       FixtureKit.runner.adapter.execute do |context|
-        @data = MemoryCache.new(
+        @content = MemoryCache.new(
           data: evaluate(FixtureKit.runner.coders, context),
           exposed: file_cache.serialize_exposed(fixture.definition.exposed)
         )
       end
 
-      file_cache.write(data)
+      file_cache.write(content)
     end
 
     private
 
-    def evaluate(coders, context, memo = {}, &block)
+    def evaluate(coders, context, data = {}, &block)
       if coders.empty?
         fixture.definition.evaluate(context, parent: fixture.parent&.mount)
       else
         coder, *remaining_coders = coders
 
-        parent_data = fixture.parent ? fixture.parent.cache.data.data_for(coder.class) : nil
-        memo[coder.class] = coder.save(parent_data: parent_data) do
-          evaluate(remaining_coders, context, memo, &block)
+        parent_data = fixture.parent ? fixture.parent.cache.content.data_for(coder.class) : nil
+        data[coder.class] = coder.save(parent_data: parent_data) do
+          evaluate(remaining_coders, context, data, &block)
         end
       end
 
-      memo
+      data
     end
 
     def file_cache

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -43,7 +43,7 @@ module FixtureKit
       @content ||= file_cache.read
 
       FixtureKit.runner.coders.each do |coder|
-        coder.load(content.data_for(coder.class))
+        coder.mount(content.data_for(coder.class))
       end
 
       Repository.new(content.exposed)
@@ -69,7 +69,7 @@ module FixtureKit
         coder, *remaining_coders = coders
 
         parent_data = fixture.parent ? fixture.parent.cache.content.data_for(coder.class) : nil
-        data[coder.class] = coder.save(parent_data: parent_data) do
+        data[coder.class] = coder.generate(parent_data: parent_data) do
           evaluate(remaining_coders, context, data, &block)
         end
       end

--- a/lib/fixture_kit/coder.rb
+++ b/lib/fixture_kit/coder.rb
@@ -2,12 +2,12 @@
 
 module FixtureKit
   class Coder
-    def save(parent_data: nil, &block)
-      raise NotImplementedError, "#{self.class} must implement #save"
+    def generate(parent_data: nil, &block)
+      raise NotImplementedError, "#{self.class} must implement #generate"
     end
 
-    def load(data)
-      raise NotImplementedError, "#{self.class} must implement #load"
+    def mount(data)
+      raise NotImplementedError, "#{self.class} must implement #mount"
     end
 
     def encode(data)

--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -8,7 +8,7 @@ module FixtureKit
     EVENT = "sql.active_record"
     NAME_PATTERN = /\A(?<model_name>.+?) (?:(?:Bulk )?(?:Insert|Upsert)|Create|Destroy|(?:Update|Delete)(?: All)?)\z/
 
-    def save(parent_data: nil, &block)
+    def generate(parent_data: nil, &block)
       captured_models = Set.new
       subscriber = lambda do |_event_name, _start, _finish, _id, payload|
         name = payload[:name].to_s
@@ -26,7 +26,7 @@ module FixtureKit
       generate_statements(captured_models)
     end
 
-    def load(data)
+    def mount(data)
       statements_by_connection(data).each do |connection, statements|
         connection.disable_referential_integrity do
           # execute_batch is private in current supported Rails versions.

--- a/lib/fixture_kit/file_cache.rb
+++ b/lib/fixture_kit/file_cache.rb
@@ -19,9 +19,9 @@ module FixtureKit
     def read
       file_data = JSON.parse(File.read(path))
 
-      data = file_data.fetch("data").each_with_object({}) do |(coder_name, coder_data), hash|
-        coder_class = ActiveSupport::Inflector.constantize(coder_name)
-        hash[coder_class] = coder_class.new.decode(coder_data)
+      data = file_data.fetch("data").to_h do |coder_name, coder_data|
+        coder = coder_for(coder_name)
+        [coder.class, coder.decode(coder_data)]
       end
 
       exposed = file_data.fetch("exposed").each_with_object({}) do |(name, value), hash|
@@ -38,7 +38,8 @@ module FixtureKit
     def write(data)
       file_data = {
         data: data.data.to_h do |coder_class, coder_data|
-          [coder_class, coder_class.new.encode(coder_data)]
+          coder = coder_for(coder_class.name)
+          [coder.class, coder.encode(coder_data)]
         end,
         exposed: data.exposed,
       }
@@ -55,6 +56,13 @@ module FixtureKit
           hash[name] = { record.class => record.id }
         end
       end
+    end
+
+    private
+
+    def coder_for(class_name)
+      @coder_for ||= FixtureKit.runner.coders.index_by { |c| c.class.name }
+      @coder_for.fetch(class_name)
     end
   end
 end

--- a/lib/fixture_kit/file_cache.rb
+++ b/lib/fixture_kit/file_cache.rb
@@ -17,14 +17,14 @@ module FixtureKit
     end
 
     def read
-      file_data = JSON.parse(File.read(path))
+      content = JSON.parse(File.read(path))
 
-      data = file_data.fetch("data").to_h do |coder_name, coder_data|
+      data = content.fetch("data").to_h do |coder_name, coder_data|
         coder = coder_for(coder_name)
         [coder.class, coder.decode(coder_data)]
       end
 
-      exposed = file_data.fetch("exposed").each_with_object({}) do |(name, value), hash|
+      exposed = content.fetch("exposed").each_with_object({}) do |(name, value), hash|
         if value.is_a?(Array)
           hash[name.to_sym] = value.map { |r| { ActiveSupport::Inflector.constantize(r.keys.first) => r.values.first } }
         else
@@ -36,7 +36,7 @@ module FixtureKit
     end
 
     def write(data)
-      file_data = {
+      content = {
         data: data.data.to_h do |coder_class, coder_data|
           coder = coder_for(coder_class.name)
           [coder.class, coder.encode(coder_data)]
@@ -45,7 +45,7 @@ module FixtureKit
       }
 
       FileUtils.mkdir_p(File.dirname(path))
-      File.write(path, JSON.pretty_generate(file_data))
+      File.write(path, JSON.pretty_generate(content))
     end
 
     def serialize_exposed(exposed)

--- a/lib/fixture_kit/runner.rb
+++ b/lib/fixture_kit/runner.rb
@@ -30,6 +30,10 @@ module FixtureKit
       @adapter ||= configuration.adapter.new(configuration.adapter_options)
     end
 
+    def coders
+      @coders ||= configuration.coders.map(&:new)
+    end
+
     def started?
       @started
     end

--- a/spec/unit/coders/active_record_coder_spec.rb
+++ b/spec/unit/coders/active_record_coder_spec.rb
@@ -36,17 +36,17 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     destroyed.destroy!
   end
 
-  describe "#save" do
+  describe "#generate" do
     it "captures user model writes for all supported write operation types" do
       suffix = SecureRandom.hex(6)
 
-      result = coder.save { exercise_user_write_operations(suffix) }
+      result = coder.generate { exercise_user_write_operations(suffix) }
 
       expect(result).to have_key(User)
     end
 
     it "resolves STI subclasses to their base table-owning model" do
-      result = coder.save do
+      result = coder.generate do
         Car.create!(name: "Sedan", year: 2024)
         Truck.create!(name: "Pickup", year: 2023)
       end
@@ -55,7 +55,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     end
 
     it "resolves STI subclasses whose base model inherits directly from ActiveRecord::Base" do
-      result = coder.save do
+      result = coder.generate do
         Phone.create!(name: "iPhone")
         Tablet.create!(name: "iPad")
       end
@@ -66,7 +66,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     it "captures models written with update operations" do
       user = User.create!(name: "Alice", email: "alice-update@example.com")
 
-      result = coder.save { User.find(user.id).update!(name: "Alice Updated") }
+      result = coder.generate { User.find(user.id).update!(name: "Alice Updated") }
 
       expect(result).to have_key(User)
     end
@@ -75,7 +75,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
       User.create!(name: "Alice", email: "alice-delete@example.com")
       doomed = User.create!(name: "Bob", email: "bob-delete@example.com")
 
-      result = coder.save { doomed.destroy! }
+      result = coder.generate { doomed.destroy! }
 
       expect(result).to have_key(User)
     end
@@ -83,7 +83,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     it "generates INSERT statements for captured models" do
       User.create!(name: "Alice", email: "alice-save@example.com")
 
-      result = coder.save { User.create!(name: "Bob", email: "bob-save@example.com") }
+      result = coder.generate { User.create!(name: "Bob", email: "bob-save@example.com") }
 
       expect(result[User]).to match(/INSERT INTO/)
     end
@@ -91,14 +91,14 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     it "stores nil sql for a model when its table is empty after changes" do
       user = User.create!(name: "Alice", email: "alice-empty@example.com")
 
-      expect(coder.save { user.destroy! }[User]).to be_nil
+      expect(coder.generate { user.destroy! }[User]).to be_nil
     end
 
     it "includes models from parent_data that were not directly captured" do
       User.create!(name: "Alice", email: "alice-parent@example.com")
 
       parent_data = { User => "INSERT INTO users ..." }
-      result = coder.save(parent_data: parent_data) do
+      result = coder.generate(parent_data: parent_data) do
         Project.create!(name: "Project", owner: User.find_by!(email: "alice-parent@example.com"))
       end
 
@@ -106,7 +106,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
     end
   end
 
-  describe "#load" do
+  describe "#mount" do
     it "documents that connection execute_batch is currently private" do
       connection = User.connection
 
@@ -144,7 +144,7 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
       expect(analytics_connection).to receive(:disable_referential_integrity).once.and_yield
       expect(analytics_connection).to receive(:execute_batch).with(analytics_statements, "FixtureKit Load").once
 
-      coder.load(records)
+      coder.mount(records)
     end
   end
 

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -396,12 +396,12 @@ RSpec.describe FixtureKit::Cache do
   describe "with a secondary coder" do
     let(:secondary_coder) do
       klass = Class.new(FixtureKit::Coder) do
-        def save(parent_data: nil, &block)
+        def generate(parent_data: nil, &block)
           yield
           { "key" => "value" }
         end
 
-        def load(data)
+        def mount(data)
         end
       end
       stub_const("FixtureKit::SecondaryCoder", klass)
@@ -442,7 +442,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
       fixture_cache.clear_memory
 
-      expect_any_instance_of(FixtureKit::SecondaryCoder).to receive(:load).with({ "key" => "value" }).and_call_original
+      expect_any_instance_of(FixtureKit::SecondaryCoder).to receive(:mount).with({ "key" => "value" }).and_call_original
       fixture_cache.load
     end
   end
@@ -450,12 +450,12 @@ RSpec.describe FixtureKit::Cache do
   describe "with a secondary coder that defines custom encode/decode" do
     let(:secondary_coder) do
       klass = Class.new(FixtureKit::Coder) do
-        def save(parent_data: nil, &block)
+        def generate(parent_data: nil, &block)
           yield if block_given?
           { "raw" => "value" }
         end
 
-        def load(data)
+        def mount(data)
         end
 
         def encode(data)
@@ -504,7 +504,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
       fixture_cache.clear_memory
 
-      expect_any_instance_of(FixtureKit::EncodingCoder).to receive(:load).with({ "raw" => "value" }).and_call_original
+      expect_any_instance_of(FixtureKit::EncodingCoder).to receive(:mount).with({ "raw" => "value" }).and_call_original
       fixture_cache.load
     end
   end

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe FixtureKit::Cache do
         data: { FixtureKit::ActiveRecordCoder => { User => nil } },
         exposed: {}
       )
-      parent_cache = instance_double(FixtureKit::Cache, data: parent_cache_data)
+      parent_cache = instance_double(FixtureKit::Cache, content: parent_cache_data)
       parent_fixture = instance_double(FixtureKit::Fixture, cache: parent_cache)
       allow(parent_fixture).to receive(:mount) do
         User.create!(name: "Parent Owner", email: "parent-owner@example.com")
@@ -259,12 +259,12 @@ RSpec.describe FixtureKit::Cache do
   end
 
   describe "#clear_memory" do
-    it "nils out @data" do
-      cache.instance_variable_set(:@data, FixtureKit::MemoryCache.new(data: {}, exposed: {}))
+    it "nils out @content" do
+      cache.instance_variable_set(:@content, FixtureKit::MemoryCache.new(data: {}, exposed: {}))
 
       cache.clear_memory
 
-      expect(cache.data).to be_nil
+      expect(cache.content).to be_nil
     end
 
     it "still reports exists? as true when file cache is present" do
@@ -283,7 +283,7 @@ RSpec.describe FixtureKit::Cache do
 
       fixture_cache.clear_memory
 
-      expect(fixture_cache.data).to be_nil
+      expect(fixture_cache.content).to be_nil
       expect(fixture_cache.exists?).to be(true)
     end
 
@@ -302,12 +302,12 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
 
       fixture_cache.clear_memory
-      expect(fixture_cache.data).to be_nil
+      expect(fixture_cache.content).to be_nil
 
       User.delete_all
       repository = fixture_cache.load
 
-      expect(fixture_cache.data).not_to be_nil
+      expect(fixture_cache.content).not_to be_nil
       expect(repository.alice).to be_a(User)
       expect(repository.alice.name).to eq("Alice")
     end
@@ -329,7 +329,7 @@ RSpec.describe FixtureKit::Cache do
       allow(cache).to receive(:exists?).and_return(true)
       allow(FixtureKit::Repository).to receive(:new).with({}).and_return(:repository)
       cache.instance_variable_set(
-        :@data,
+        :@content,
         FixtureKit::MemoryCache.new(
           data: {
             FixtureKit::ActiveRecordCoder => {


### PR DESCRIPTION
## Summary

- Avoids creating new coder instances on every `save` and `load` call by memoizing them on the runner
- `FileCache#read` and `FileCache#write` also reuse the same instances via a private `coder_for` helper rather than calling `.new` inline
- Some opportunistic renames:
  - `Cache#data` -> `Cache#content`
  - `Coder#save` -> `Coder#generate`
  - `Coder#load` -> `Coder#mount`

## Test plan

- [x] Existing cache and file cache specs continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)