### PR TITLE
Rename mount label to "FixtureKit Insert" and harden coder subscriber

### DIFF
--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -15,7 +15,10 @@ module FixtureKit
         model_name = name[NAME_PATTERN, :model_name]
         next unless model_name
 
-        captured_models.add(ActiveSupport::Inflector.constantize(model_name))
+        klass = ActiveSupport::Inflector.safe_constantize(model_name)
+        next unless klass.is_a?(Class) && klass < ActiveRecord::Base
+
+        captured_models.add(klass)
       end
 
       ActiveSupport::Notifications.subscribed(subscriber, EVENT, monotonic: true, &block)
@@ -31,7 +34,7 @@ module FixtureKit
         connection.disable_referential_integrity do
           # execute_batch is private in current supported Rails versions.
           # This should be revisited when Rails 8.2 makes it public.
-          connection.__send__(:execute_batch, statements, "FixtureKit Load")
+          connection.__send__(:execute_batch, statements, "FixtureKit Insert")
         end
       end
     end

--- a/spec/unit/coders/active_record_coder_spec.rb
+++ b/spec/unit/coders/active_record_coder_spec.rb
@@ -140,9 +140,9 @@ RSpec.describe FixtureKit::ActiveRecordCoder do
       ]
 
       expect(primary_connection).to receive(:disable_referential_integrity).once.and_yield
-      expect(primary_connection).to receive(:execute_batch).with(primary_statements, "FixtureKit Load").once
+      expect(primary_connection).to receive(:execute_batch).with(primary_statements, "FixtureKit Insert").once
       expect(analytics_connection).to receive(:disable_referential_integrity).once.and_yield
-      expect(analytics_connection).to receive(:execute_batch).with(analytics_statements, "FixtureKit Load").once
+      expect(analytics_connection).to receive(:execute_batch).with(analytics_statements, "FixtureKit Insert").once
 
       coder.mount(records)
     end

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -356,9 +356,9 @@ RSpec.describe FixtureKit::Cache do
       ]
 
       expect(primary_connection).to receive(:disable_referential_integrity).once.and_yield
-      expect(primary_connection).to receive(:execute_batch).with(primary_statements, "FixtureKit Load").once
+      expect(primary_connection).to receive(:execute_batch).with(primary_statements, "FixtureKit Insert").once
       expect(analytics_connection).to receive(:disable_referential_integrity).once.and_yield
-      expect(analytics_connection).to receive(:execute_batch).with(analytics_statements, "FixtureKit Load").once
+      expect(analytics_connection).to receive(:execute_batch).with(analytics_statements, "FixtureKit Insert").once
 
       expect(cache.load).to eq(:repository)
     end


### PR DESCRIPTION
## Summary

- Rename the `execute_batch` label from `"FixtureKit Load"` → `"FixtureKit Insert"` to match Rails' fixture insert naming convention.
- Harden `ActiveRecordCoder`'s `sql.active_record` subscriber: use `safe_constantize` and require the result to be a `Class < ActiveRecord::Base` before capturing it.

## Why both in one PR

The label rename causes a feedback loop: `"FixtureKit Insert"` matches the coder's own `NAME_PATTERN` (which recognizes `Insert` as a write verb). Under fixture inheritance, the parent's mount notification then feeds into the child's `generate` subscriber, which calls `constantize("FixtureKit")` — the module, not a class — and crashes in `base_table_model`.

The subscriber hardening is the right fix regardless (any non-AR class name in a SQL log would have the same issue), but it's a strict prerequisite for the rename, so they go together.

## Test plan

- [x] Existing unit tests pass with the renamed label
- [x] CI green across all matrix entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)