### PR TITLE
Group mount work by connection pool and use pool.with_connection

### DIFF
--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -30,11 +30,17 @@ module FixtureKit
     end
 
     def mount(data)
-      statements_by_connection(data).each do |connection, statements|
-        connection.disable_referential_integrity do
-          # execute_batch is private in current supported Rails versions.
-          # This should be revisited when Rails 8.2 makes it public.
-          connection.__send__(:execute_batch, statements, "FixtureKit Insert")
+      models_by_pool(data).each do |pool, models|
+        pool.with_connection do |connection|
+          statements = models.flat_map do |model|
+            [build_delete_sql(connection, model.table_name), data[model]].compact
+          end
+
+          connection.disable_referential_integrity do
+            # execute_batch is private in current supported Rails versions.
+            # This should be revisited when Rails 8.2 makes it public.
+            connection.__send__(:execute_batch, statements, "FixtureKit Insert")
+          end
         end
       end
     end
@@ -70,8 +76,8 @@ module FixtureKit
       end
     end
 
-    def build_delete_sql(model)
-      "DELETE FROM #{model.quoted_table_name}"
+    def build_delete_sql(connection, table_name)
+      "DELETE FROM #{connection.quote_table_name(table_name)}"
     end
 
     def build_insert_sql(table_name, columns, rows, connection)
@@ -81,19 +87,15 @@ module FixtureKit
       "INSERT INTO #{quoted_table} (#{quoted_columns.join(", ")}) VALUES #{rows.join(", ")}"
     end
 
-    def statements_by_connection(records)
-      deleted_tables = Set.new
+    def models_by_pool(data)
+      seen = Set.new
 
-      records.each_with_object({}) do |(model, sql), grouped|
-        connection = model.connection
-        grouped[connection] ||= []
+      data.each_with_object({}) do |(model, _), grouped|
+        pool = model.connection_pool
+        next unless seen.add?([pool, model.table_name])
 
-        table_key = [connection, model.table_name]
-        if deleted_tables.add?(table_key)
-          grouped[connection] << build_delete_sql(model)
-        end
-
-        grouped[connection] << sql if sql
+        grouped[pool] ||= []
+        grouped[pool] << model
       end
     end
   end


### PR DESCRIPTION
## Summary

Mirror Rails' fixture loading idiom in `ActiveRecordCoder#mount`:

- Group models by `connection_pool` instead of `connection`
- Wrap the batch execution in `pool.with_connection`
- Thread the explicit connection through `build_delete_sql` so we don't keep redundantly calling `model.connection`

## Why

`connection_pool` is the stable identity for "this model's connection source." `model.connection` returns whatever connection the current thread/role happens to have checked out. `pool.with_connection` is the canonical lifecycle primitive — yields the leased connection if one exists, else checks out + checks in.

Behaviorally identical inside an rspec-rails transactional fixture (the test thread already has a connection leased), but more correct under role switching, multi-DB, or programmatic use of mount outside a test transaction.

## Stack

Stacked on #53. Will rebase as that lands.

## Test plan

- [x] Existing unit tests pass (the integration test "aggregates restore queries..." uses real pools that yield the real connection through `with_connection`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)