### PR TITLE
Skip virtual columns when generating cached fixture INSERTs

### DIFF
--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -60,20 +60,26 @@ module FixtureKit
 
     def generate_statements(models)
       models.each_with_object({}) do |model, statements|
-        columns = model.column_names
+        columns = insertable_columns(model)
+        column_names = columns.map(&:name)
 
         rows = []
         model.unscoped.order(:id).find_each do |record|
-          row_values = columns.map do |col|
+          row_values = column_names.map do |col|
             value = record.read_attribute_before_type_cast(col)
             model.connection.quote(value)
           end
           rows << "(#{row_values.join(", ")})"
         end
 
-        sql = rows.empty? ? nil : build_insert_sql(model.table_name, columns, rows, model.connection)
+        sql = rows.empty? ? nil : build_insert_sql(model.table_name, column_names, rows, model.connection)
         statements[model] = sql
       end
+    end
+
+    def insertable_columns(model)
+      supports_virtual = model.connection.supports_virtual_columns?
+      model.columns.reject { |c| supports_virtual && c.virtual? }
     end
 
     def build_delete_sql(connection, table_name)

--- a/spec/dummy/app/models/computed_widget.rb
+++ b/spec/dummy/app/models/computed_widget.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ComputedWidget < ApplicationRecord
+end

--- a/spec/integration/virtual_columns_spec.rb
+++ b/spec/integration/virtual_columns_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Models with generated/virtual columns can't accept INSERTs into those
+# columns. The coder must filter them out when building cached statements.
+RSpec.describe "Fixture round-trip with virtual columns" do
+  fixture do
+    ComputedWidget.create!(name: "alpha", quantity: 1)
+    ComputedWidget.create!(name: "beta", quantity: 2)
+  end
+
+  after { ComputedWidget.delete_all }
+
+  it "loads records with their generated column values" do
+    widgets = ComputedWidget.order(:id).to_a
+
+    expect(widgets.map(&:name)).to eq(["alpha", "beta"])
+    expect(widgets.map(&:name_upper)).to eq(["ALPHA", "BETA"])
+  end
+end

--- a/spec/support/dummy_rails_helper.rb
+++ b/spec/support/dummy_rails_helper.rb
@@ -34,6 +34,7 @@ def setup_databases
     ActiveRecord::Base.connection.drop_table(:users, if_exists: true)
     ActiveRecord::Base.connection.drop_table(:vehicles, if_exists: true)
     ActiveRecord::Base.connection.drop_table(:gadgets, if_exists: true)
+    ActiveRecord::Base.connection.drop_table(:computed_widgets, if_exists: true)
   end
 
   AnalyticsRecord.connection.disable_referential_integrity do
@@ -85,6 +86,13 @@ def setup_databases
   ActiveRecord::Base.connection.create_table :gadgets, force: true do |t|
     t.string :type, null: false
     t.string :name, null: false
+    t.timestamps
+  end
+
+  ActiveRecord::Base.connection.create_table :computed_widgets, force: true do |t|
+    t.string :name, null: false
+    t.integer :quantity, null: false, default: 0
+    t.virtual :name_upper, type: :string, as: "UPPER(name)", stored: true
     t.timestamps
   end
 


### PR DESCRIPTION
## Summary

Filter virtual/generated columns from the cached INSERT statements built in `ActiveRecordCoder#generate_statements`. Without this, any model with a `t.virtual` column crashes mount with `cannot INSERT into generated column`.

Mirrors how Rails' `build_fixture_sql` filters them.

## Repro

Adds a `computed_widgets` table to the dummy app with a stored generated column (`name_upper`) and a regression spec that:

1. Creates two widgets in a fixture block
2. Mounts the cached fixture
3. Asserts both names round-tripped correctly **and** the generated column reflects the source values (`UPPER(name)`)

Verified locally: without the fix, the spec fails with `SQLite3::SQLException: cannot INSERT into generated column "name_upper"`.

## Stack

Stacked on #54.

## Test plan

- [x] New regression spec passes
- [x] All existing unit + integration specs pass on sqlite
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)