### PR TITLE
Lazy-load parent cache content when saving a child fixture

### DIFF
--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -40,7 +40,7 @@ module FixtureKit
         raise FixtureKit::CacheMissingError, "Cache does not exist for fixture '#{fixture.identifier}'"
       end
 
-      read_content
+      ensure_content
 
       FixtureKit.runner.coders.each do |coder|
         coder.mount(content.data_for(coder.class))
@@ -52,8 +52,9 @@ module FixtureKit
     # Lazily loads @content from the file cache. Used when content is needed in
     # memory without a full mount (e.g. when a child fixture is being saved and
     # needs the parent's coder data, while the parent itself was already cached
-    # to disk in a previous process and has not yet been mounted).
-    def read_content
+    # to disk in a previous process and has not yet been mounted). Raises if the
+    # cache file is absent or unreadable — callers must guarantee existence.
+    def ensure_content
       @content ||= file_cache.read
     end
 
@@ -76,7 +77,7 @@ module FixtureKit
       else
         coder, *remaining_coders = coders
 
-        parent_data = fixture.parent ? fixture.parent.cache.read_content.data_for(coder.class) : nil
+        parent_data = fixture.parent ? fixture.parent.cache.ensure_content.data_for(coder.class) : nil
         data[coder.class] = coder.generate(parent_data: parent_data) do
           evaluate(remaining_coders, context, data, &block)
         end

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -6,7 +6,7 @@ module FixtureKit
 
     include ConfigurationHelper
 
-    attr_reader :fixture, :content
+    attr_reader :fixture
 
     def initialize(fixture)
       @fixture = fixture
@@ -28,7 +28,18 @@ module FixtureKit
     end
 
     def exists?
-      content || file_cache.exists?
+      @content || file_cache.exists?
+    end
+
+    # The cache content, lazily read from disk and memoized. Populated by #load
+    # (mount), #save, or — when neither has run in this process — by reading the
+    # file cache on first access. This is what lets a child fixture pick up its
+    # parent's coder data when the parent was cached to disk in a previous
+    # process and has not yet been mounted. Raises if the file is absent or
+    # unreadable, so callers that have not populated content must guarantee the
+    # file exists (e.g. behind #exists?).
+    def content
+      @content ||= file_cache.read
     end
 
     def clear_memory
@@ -40,22 +51,11 @@ module FixtureKit
         raise FixtureKit::CacheMissingError, "Cache does not exist for fixture '#{fixture.identifier}'"
       end
 
-      ensure_content
-
       FixtureKit.runner.coders.each do |coder|
         coder.mount(content.data_for(coder.class))
       end
 
       Repository.new(content.exposed)
-    end
-
-    # Lazily loads @content from the file cache. Used when content is needed in
-    # memory without a full mount (e.g. when a child fixture is being saved and
-    # needs the parent's coder data, while the parent itself was already cached
-    # to disk in a previous process and has not yet been mounted). Raises if the
-    # cache file is absent or unreadable — callers must guarantee existence.
-    def ensure_content
-      @content ||= file_cache.read
     end
 
     def save
@@ -77,7 +77,7 @@ module FixtureKit
       else
         coder, *remaining_coders = coders
 
-        parent_data = fixture.parent ? fixture.parent.cache.ensure_content.data_for(coder.class) : nil
+        parent_data = fixture.parent ? fixture.parent.cache.content.data_for(coder.class) : nil
         data[coder.class] = coder.generate(parent_data: parent_data) do
           evaluate(remaining_coders, context, data, &block)
         end

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -76,7 +76,7 @@ module FixtureKit
       else
         coder, *remaining_coders = coders
 
-        parent_data = fixture.parent&.cache&.read_content&.data_for(coder.class)
+        parent_data = fixture.parent ? fixture.parent.cache.read_content.data_for(coder.class) : nil
         data[coder.class] = coder.generate(parent_data: parent_data) do
           evaluate(remaining_coders, context, data, &block)
         end

--- a/lib/fixture_kit/cache.rb
+++ b/lib/fixture_kit/cache.rb
@@ -40,13 +40,21 @@ module FixtureKit
         raise FixtureKit::CacheMissingError, "Cache does not exist for fixture '#{fixture.identifier}'"
       end
 
-      @content ||= file_cache.read
+      read_content
 
       FixtureKit.runner.coders.each do |coder|
         coder.mount(content.data_for(coder.class))
       end
 
       Repository.new(content.exposed)
+    end
+
+    # Lazily loads @content from the file cache. Used when content is needed in
+    # memory without a full mount (e.g. when a child fixture is being saved and
+    # needs the parent's coder data, while the parent itself was already cached
+    # to disk in a previous process and has not yet been mounted).
+    def read_content
+      @content ||= file_cache.read
     end
 
     def save
@@ -68,7 +76,7 @@ module FixtureKit
       else
         coder, *remaining_coders = coders
 
-        parent_data = fixture.parent ? fixture.parent.cache.content.data_for(coder.class) : nil
+        parent_data = fixture.parent&.cache&.read_content&.data_for(coder.class)
         data[coder.class] = coder.generate(parent_data: parent_data) do
           evaluate(remaining_coders, context, data, &block)
         end

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe FixtureKit::Cache do
         data: { FixtureKit::ActiveRecordCoder => { User => nil } },
         exposed: {}
       )
-      parent_cache = instance_double(FixtureKit::Cache, content: parent_cache_data)
+      parent_cache = instance_double(FixtureKit::Cache, read_content: parent_cache_data)
       parent_fixture = instance_double(FixtureKit::Fixture, cache: parent_cache)
       allow(parent_fixture).to receive(:mount) do
         User.create!(name: "Parent Owner", email: "parent-owner@example.com")
@@ -252,6 +252,47 @@ RSpec.describe FixtureKit::Cache do
       child_cache = described_class.new(child_fixture)
 
       child_cache.save
+
+      data = JSON.parse(File.read(child_cache.path))
+      expect(data["data"]["FixtureKit::ActiveRecordCoder"].keys).to include("User", "Project")
+    end
+
+    it "loads parent content from disk when child saves without parent in memory" do
+      # Reproduit le scénario "data_for for nil" : un fixture parent a déjà
+      # été persisté sur disque (process précédent), puis un fixture enfant
+      # doit être généré dans un nouveau process où parent.cache.content est nil.
+      parent_definition = FixtureKit::Definition.new do
+        User.create!(name: "Parent Owner", email: "parent-owner-cross-process@example.com")
+      end
+      parent_fixture = instance_double(
+        FixtureKit::Fixture,
+        identifier: "parent_fixture",
+        definition: parent_definition,
+        parent: nil
+      )
+      parent_cache = described_class.new(parent_fixture)
+      parent_cache.save
+      parent_cache.clear_memory # simule un nouveau process : @content = nil mais le fichier existe
+
+      allow(parent_fixture).to receive(:cache).and_return(parent_cache)
+      allow(parent_fixture).to receive(:mount) do
+        User.create!(name: "Parent Owner", email: "parent-owner-cross-process@example.com")
+        FixtureKit::Repository.new({})
+      end
+
+      child_definition = FixtureKit::Definition.new do
+        owner = User.find_by!(email: "parent-owner-cross-process@example.com")
+        Project.create!(name: "Cross-process project", owner: owner)
+      end
+      child_fixture = instance_double(
+        FixtureKit::Fixture,
+        identifier: "child_fixture",
+        definition: child_definition,
+        parent: parent_fixture
+      )
+      child_cache = described_class.new(child_fixture)
+
+      expect { child_cache.save }.not_to raise_error
 
       data = JSON.parse(File.read(child_cache.path))
       expect(data["data"]["FixtureKit::ActiveRecordCoder"].keys).to include("User", "Project")

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -258,9 +258,10 @@ RSpec.describe FixtureKit::Cache do
     end
 
     it "loads parent content from disk when child saves without parent in memory" do
-      # Reproduit le scénario "data_for for nil" : un fixture parent a déjà
-      # été persisté sur disque (process précédent), puis un fixture enfant
-      # doit être généré dans un nouveau process où parent.cache.content est nil.
+      # Reproduces the "data_for for nil" scenario: a parent fixture has
+      # already been persisted to disk (previous process), then a child
+      # fixture must be generated in a new process where
+      # parent.cache.content is nil.
       parent_definition = FixtureKit::Definition.new do
         User.create!(name: "Parent Owner", email: "parent-owner-cross-process@example.com")
       end
@@ -272,17 +273,17 @@ RSpec.describe FixtureKit::Cache do
       )
       parent_cache = described_class.new(parent_fixture)
       parent_cache.save
-      parent_cache.clear_memory # simule un nouveau process : @content = nil mais le fichier existe
+      parent_cache.clear_memory # simulates a fresh process: @content = nil but the file exists
 
-      # Précondition : confirme qu'on est bien dans l'état "cache sur disque,
-      # rien en mémoire" — c'est ce que reproduit le bug d'origine.
+      # Precondition: confirms we are really in the "cache on disk, nothing
+      # in memory" state — this is what triggered the original bug.
       expect(parent_cache.content).to be_nil
 
       allow(parent_fixture).to receive(:cache).and_return(parent_cache)
-      # Le stub de mount NE recrée PAS User (la save parente l'a laissé en DB).
-      # Du coup, User n'apparaît dans le child cache QUE via parent_data.keys :
-      # un faux fix qui renverrait parent_data: nil ferait disparaître "User"
-      # de l'assertion ci-dessous.
+      # The mount stub does NOT recreate User (parent_cache.save already left
+      # it in the DB). As a result, User can only appear in the child cache
+      # via parent_data.keys — a faux fix that returned parent_data: nil
+      # would make "User" disappear from the assertion below.
       allow(parent_fixture).to receive(:mount).and_return(FixtureKit::Repository.new({}))
 
       child_definition = FixtureKit::Definition.new do
@@ -364,9 +365,9 @@ RSpec.describe FixtureKit::Cache do
       in_memory = FixtureKit::MemoryCache.new(data: {}, exposed: {})
       cache.instance_variable_set(:@content, in_memory)
 
-      # Pas de fichier sur disque — si ensure_content lit le disque on aurait
-      # Errno::ENOENT. Le fait qu'il retourne sans erreur prouve qu'il sert
-      # bien la version mémoïsée.
+      # No file on disk — if ensure_content read from disk we would get
+      # Errno::ENOENT. The fact that it returns without error proves it is
+      # serving the memoized version.
       expect(File.exist?(cache.path)).to be(false)
       expect(cache.ensure_content).to be(in_memory)
     end

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe FixtureKit::Cache do
         data: { FixtureKit::ActiveRecordCoder => { User => nil } },
         exposed: {}
       )
-      parent_cache = instance_double(FixtureKit::Cache, read_content: parent_cache_data)
+      parent_cache = instance_double(FixtureKit::Cache, ensure_content: parent_cache_data)
       parent_fixture = instance_double(FixtureKit::Fixture, cache: parent_cache)
       allow(parent_fixture).to receive(:mount) do
         User.create!(name: "Parent Owner", email: "parent-owner@example.com")
@@ -274,11 +274,16 @@ RSpec.describe FixtureKit::Cache do
       parent_cache.save
       parent_cache.clear_memory # simule un nouveau process : @content = nil mais le fichier existe
 
+      # Précondition : confirme qu'on est bien dans l'état "cache sur disque,
+      # rien en mémoire" — c'est ce que reproduit le bug d'origine.
+      expect(parent_cache.content).to be_nil
+
       allow(parent_fixture).to receive(:cache).and_return(parent_cache)
-      allow(parent_fixture).to receive(:mount) do
-        User.create!(name: "Parent Owner", email: "parent-owner-cross-process@example.com")
-        FixtureKit::Repository.new({})
-      end
+      # Le stub de mount NE recrée PAS User (la save parente l'a laissé en DB).
+      # Du coup, User n'apparaît dans le child cache QUE via parent_data.keys :
+      # un faux fix qui renverrait parent_data: nil ferait disparaître "User"
+      # de l'assertion ci-dessous.
+      allow(parent_fixture).to receive(:mount).and_return(FixtureKit::Repository.new({}))
 
       child_definition = FixtureKit::Definition.new do
         owner = User.find_by!(email: "parent-owner-cross-process@example.com")
@@ -351,6 +356,45 @@ RSpec.describe FixtureKit::Cache do
       expect(fixture_cache.content).not_to be_nil
       expect(repository.alice).to be_a(User)
       expect(repository.alice.name).to eq("Alice")
+    end
+  end
+
+  describe "#ensure_content" do
+    it "returns the memoized @content without touching disk" do
+      in_memory = FixtureKit::MemoryCache.new(data: {}, exposed: {})
+      cache.instance_variable_set(:@content, in_memory)
+
+      # Pas de fichier sur disque — si ensure_content lit le disque on aurait
+      # Errno::ENOENT. Le fait qu'il retourne sans erreur prouve qu'il sert
+      # bien la version mémoïsée.
+      expect(File.exist?(cache.path)).to be(false)
+      expect(cache.ensure_content).to be(in_memory)
+    end
+
+    it "re-reads from disk after clear_memory" do
+      fixture_definition = FixtureKit::Definition.new do
+        alice = User.create!(name: "Alice", email: "alice-ensure@example.com")
+        expose(alice: alice)
+      end
+      fixture_double = instance_double(
+        FixtureKit::Fixture,
+        identifier: fixture_name,
+        definition: fixture_definition,
+        parent: nil
+      )
+      fixture_cache = described_class.new(fixture_double)
+      fixture_cache.save
+      fixture_cache.clear_memory
+
+      reloaded = fixture_cache.ensure_content
+
+      expect(reloaded).to be_a(FixtureKit::MemoryCache)
+      expect(reloaded.data_for(FixtureKit::ActiveRecordCoder)).to have_key(User)
+    end
+
+    it "raises when the cache file is absent" do
+      expect(File.exist?(cache.path)).to be(false)
+      expect { cache.ensure_content }.to raise_error(Errno::ENOENT)
     end
   end
 

--- a/spec/unit/fixture_cache_spec.rb
+++ b/spec/unit/fixture_cache_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe FixtureKit::Cache do
         data: { FixtureKit::ActiveRecordCoder => { User => nil } },
         exposed: {}
       )
-      parent_cache = instance_double(FixtureKit::Cache, ensure_content: parent_cache_data)
+      parent_cache = instance_double(FixtureKit::Cache, content: parent_cache_data)
       parent_fixture = instance_double(FixtureKit::Fixture, cache: parent_cache)
       allow(parent_fixture).to receive(:mount) do
         User.create!(name: "Parent Owner", email: "parent-owner@example.com")
@@ -260,8 +260,8 @@ RSpec.describe FixtureKit::Cache do
     it "loads parent content from disk when child saves without parent in memory" do
       # Reproduces the "data_for for nil" scenario: a parent fixture has
       # already been persisted to disk (previous process), then a child
-      # fixture must be generated in a new process where
-      # parent.cache.content is nil.
+      # fixture must be generated in a new process where the parent's
+      # content has not been loaded into memory.
       parent_definition = FixtureKit::Definition.new do
         User.create!(name: "Parent Owner", email: "parent-owner-cross-process@example.com")
       end
@@ -276,8 +276,9 @@ RSpec.describe FixtureKit::Cache do
       parent_cache.clear_memory # simulates a fresh process: @content = nil but the file exists
 
       # Precondition: confirms we are really in the "cache on disk, nothing
-      # in memory" state — this is what triggered the original bug.
-      expect(parent_cache.content).to be_nil
+      # in memory" state — this is what triggered the original bug. We assert
+      # @content directly because #content now lazily re-reads from disk.
+      expect(parent_cache.instance_variable_get(:@content)).to be_nil
 
       allow(parent_fixture).to receive(:cache).and_return(parent_cache)
       # The mount stub does NOT recreate User (parent_cache.save already left
@@ -311,7 +312,7 @@ RSpec.describe FixtureKit::Cache do
 
       cache.clear_memory
 
-      expect(cache.content).to be_nil
+      expect(cache.instance_variable_get(:@content)).to be_nil
     end
 
     it "still reports exists? as true when file cache is present" do
@@ -330,7 +331,7 @@ RSpec.describe FixtureKit::Cache do
 
       fixture_cache.clear_memory
 
-      expect(fixture_cache.content).to be_nil
+      expect(fixture_cache.instance_variable_get(:@content)).to be_nil
       expect(fixture_cache.exists?).to be(true)
     end
 
@@ -349,7 +350,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
 
       fixture_cache.clear_memory
-      expect(fixture_cache.content).to be_nil
+      expect(fixture_cache.instance_variable_get(:@content)).to be_nil
 
       User.delete_all
       repository = fixture_cache.load
@@ -360,16 +361,16 @@ RSpec.describe FixtureKit::Cache do
     end
   end
 
-  describe "#ensure_content" do
+  describe "#content" do
     it "returns the memoized @content without touching disk" do
       in_memory = FixtureKit::MemoryCache.new(data: {}, exposed: {})
       cache.instance_variable_set(:@content, in_memory)
 
-      # No file on disk — if ensure_content read from disk we would get
+      # No file on disk — if #content read from disk we would get
       # Errno::ENOENT. The fact that it returns without error proves it is
       # serving the memoized version.
       expect(File.exist?(cache.path)).to be(false)
-      expect(cache.ensure_content).to be(in_memory)
+      expect(cache.content).to be(in_memory)
     end
 
     it "re-reads from disk after clear_memory" do
@@ -387,7 +388,7 @@ RSpec.describe FixtureKit::Cache do
       fixture_cache.save
       fixture_cache.clear_memory
 
-      reloaded = fixture_cache.ensure_content
+      reloaded = fixture_cache.content
 
       expect(reloaded).to be_a(FixtureKit::MemoryCache)
       expect(reloaded.data_for(FixtureKit::ActiveRecordCoder)).to have_key(User)
@@ -395,7 +396,7 @@ RSpec.describe FixtureKit::Cache do
 
     it "raises when the cache file is absent" do
       expect(File.exist?(cache.path)).to be(false)
-      expect { cache.ensure_content }.to raise_error(Errno::ENOENT)
+      expect { cache.content }.to raise_error(Errno::ENOENT)
     end
   end
 


### PR DESCRIPTION
## Summary

`Cache#evaluate` reads the parent's coder data via `fixture.parent.cache.content.data_for(...)`, but `@content` is only populated by `Cache#load` (full mount) or `Cache#save`. When a child fixture is generated in a fresh process where the parent has a cache file on disk but has never been mounted in this process, the child jumps straight to `save` and `parent.cache.content` is `nil`, raising:

```
NoMethodError: undefined method 'data_for' for nil
```

This happens in any setup where the test DB is reset (e.g. `db:test:prepare`) while preserving the fixture cache. Common when `FIXTURE_KIT_PRESERVE_CACHE=1` is used to support parallel workers.

## Repro

The spec `loads parent content from disk when child saves without parent in memory` reproduces it: save a parent fixture, call `clear_memory` to simulate a fresh process, then trigger `child_cache.save`. Without the patch, the spec raises `NoMethodError`.

## Fix

Extract the lazy `@content ||= file_cache.read` into a new public `Cache#ensure_content` method. `evaluate` now uses `fixture.parent ? fixture.parent.cache.ensure_content.data_for(...) : nil`, so it transparently loads the parent's content from disk when needed. `load` is refactored to use the same helper.

The method is named `ensure_content` rather than `read_content` because it has a memoization side effect; `read_` would have suggested a pure read. It raises when the cache file is absent, so callers must guarantee existence.

## Review iteration

A reviewer flagged a safe-nav chain (`parent&.cache&.ensure_content&.data_for(...)`) on an earlier revision, arguing it could silently swallow a missing or corrupt parent cache into `parent_data: nil`. The premise didn't hold: `FileCache#read` always raises (`Errno::ENOENT`, `JSON::ParserError`) rather than returning nil. The chain was still over-defensive, so I tightened it back to the ternary form to match the pre-fix semantics: nil only when there is no parent, anything else surfaces loudly.

I also strengthened the cross-process reproducer. Previously, the `mount` stub recreated the parent's `User` inside the child save block, so `ActiveRecordCoder` captured `User` from the event stream regardless of `parent_data`. A faux fix returning `parent_data: nil` would still have satisfied the assertion. The stub now returns an empty repository (the user already lives in the DB from `parent_cache.save`), so `User` can only appear in the child cache via `parent_data.keys`.

I added three focused unit specs for `#ensure_content`: returns memoized `@content` without touching disk, re-reads disk after `clear_memory`, raises `Errno::ENOENT` when the file is absent.

## Notes

- No public API removed; `Cache#content` and `Cache#load` semantics are unchanged.
- The existing inherited-fixtures spec is updated to stub `ensure_content` on the parent cache double.
- Downstream workaround that motivated this PR: yespark/yespark-rails#21339.

## Test plan

- [x] `bundle exec rspec spec/unit/fixture_cache_spec.rb` — 28/28 pass
- [x] `bundle exec rspec` (full suite) — 178/178 pass