### PR TITLE
Raise an actionable error when a cache predates a coder

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -322,6 +322,7 @@ Public error classes:
 - `FixtureKit::FixtureDefinitionNotFound`
 - `FixtureKit::RunnerAlreadyStartedError`
 - `FixtureKit::CircularFixtureInheritance`
+- `FixtureKit::MissingCoderDataError`
 
 ## Requirements
 

--- a/lib/fixture_kit.rb
+++ b/lib/fixture_kit.rb
@@ -9,6 +9,7 @@ module FixtureKit
   class FixtureDefinitionNotFound < Error; end
   class RunnerAlreadyStartedError < Error; end
   class CircularFixtureInheritance < Error; end
+  class MissingCoderDataError < Error; end
 
   autoload :VERSION, File.expand_path("fixture_kit/version", __dir__)
   autoload :Configuration, File.expand_path("fixture_kit/configuration", __dir__)

--- a/lib/fixture_kit/memory_cache.rb
+++ b/lib/fixture_kit/memory_cache.rb
@@ -11,7 +11,13 @@ module FixtureKit
     end
 
     def data_for(coder_class)
-      data.fetch(coder_class)
+      data.fetch(coder_class) do
+        raise MissingCoderDataError,
+          "The fixture cache has no data for #{coder_class}. This usually means " \
+          "the cache was written before #{coder_class} was registered as a coder. " \
+          "Regenerate the fixture cache so it includes this coder (clear the cache " \
+          "directory, or run without FIXTURE_KIT_PRESERVE_CACHE=1)."
+      end
     end
   end
 end

--- a/spec/unit/memory_cache_spec.rb
+++ b/spec/unit/memory_cache_spec.rb
@@ -20,4 +20,28 @@ RSpec.describe FixtureKit::MemoryCache do
       expect(cache).to be_frozen
     end
   end
+
+  describe "#data_for" do
+    it "returns the data stored for a coder class" do
+      cache = described_class.new(
+        data: { FixtureKit::ActiveRecordCoder => { "User" => "SQL" } },
+        exposed: {}
+      )
+
+      expect(cache.data_for(FixtureKit::ActiveRecordCoder)).to eq({ "User" => "SQL" })
+    end
+
+    it "raises an actionable error when the cache predates a coder" do
+      # A cache written before this coder was registered has no entry for it.
+      # Rather than an opaque KeyError, callers should learn the cache is stale
+      # and how to fix it — naming the coder and pointing to regeneration.
+      cache = described_class.new(data: {}, exposed: {})
+
+      expect { cache.data_for(FixtureKit::ActiveRecordCoder) }
+        .to raise_error(FixtureKit::MissingCoderDataError) do |error|
+          expect(error.message).to include("FixtureKit::ActiveRecordCoder")
+          expect(error.message).to match(/regenerate/i)
+        end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`MemoryCache#data_for` did a bare `data.fetch(coder_class)`, so when the on-disk cache had no entry for a registered coder it surfaced as an opaque `KeyError: key not found: FixtureKit::SomeCoder`, with no hint about the cause or the fix.

This happens when the consuming process has a coder registered that wasn't registered when the cache was written. The common case is `FIXTURE_KIT_PRESERVE_CACHE=1`: a cache from a previous run gets read by a process that has since added a coder. The lookup runs from both `Cache#load` (mount) and `Cache#evaluate` (parent data), so either path can hit it.

## Change

Replace the bare fetch with a `fetch` block that raises a new `FixtureKit::MissingCoderDataError`, naming the coder and pointing at cache regeneration:

```
The fixture cache has no data for FixtureKit::SomeCoder. This usually means
the cache was written before FixtureKit::SomeCoder was registered as a coder.
Regenerate the fixture cache so it includes this coder (clear the cache
directory, or run without FIXTURE_KIT_PRESERVE_CACHE=1).
```

Same fail-loud, stale-cache-hint approach the foreign-key check in `ActiveRecordCoder#mount` already uses.

## Test plan

- [x] `bundle exec rspec spec/unit/memory_cache_spec.rb`
- [x] `bundle exec rspec` (full suite)
