### PR TITLE
Document why parent_data is required in ActiveRecordCoder

### DIFF
--- a/lib/fixture_kit/coders/active_record_coder.rb
+++ b/lib/fixture_kit/coders/active_record_coder.rb
@@ -24,6 +24,16 @@ module FixtureKit
       ActiveSupport::Notifications.subscribed(subscriber, EVENT, monotonic: true, &block)
 
       captured_models.map! { |model| base_table_model(model) }
+
+      # parent_data carries the parent fixture's models forward (its keys are the
+      # parent's models). This is required, not redundant: a child replays its
+      # parent's rows by calling parent.mount inside the &block above, but those
+      # INSERTs run through execute_batch tagged "FixtureKit Insert" (see #mount),
+      # which the subscriber can't attribute to a model — so the parent's models
+      # never enter captured_models on their own. Merging them here keeps the
+      # child cache self-contained: it can be mounted without the parent's cache
+      # file present. Don't drop this without also changing how replayed rows are
+      # tagged so the subscriber can recapture them.
       captured_models.merge(parent_data.keys) if parent_data
 
       generate_statements(captured_models)
@@ -39,6 +49,11 @@ module FixtureKit
           connection.disable_referential_integrity do
             # execute_batch is private in current supported Rails versions.
             # This should be revisited when Rails 8.2 makes it public.
+            #
+            # The generic "FixtureKit Insert" tag means these replayed INSERTs
+            # are not attributable to a model by the #generate subscriber. That
+            # is why inherited fixtures pass parent models forward via parent_data
+            # rather than recapturing them here (see #generate).
             connection.__send__(:execute_batch, statements, "FixtureKit Insert")
           end
 


### PR DESCRIPTION
## Summary

`parent_data` in `ActiveRecordCoder#generate` looks removable but isn't, and nothing in the code said why. This adds the missing comments so the next person doesn't delete it and quietly break inherited fixtures.

## Why parent_data is required

A child fixture replays its parent's rows by calling `parent.mount` inside the `generate` block. Those INSERTs run through `execute_batch` under the log tag `"FixtureKit Insert"`, which the `sql.active_record` subscriber can't attribute to a model. So the parent's models never land in `captured_models` on their own. `captured_models.merge(parent_data.keys)` puts them back, which is what keeps a child cache self-contained: you can mount it without the parent's cache file on disk.

I did look at removing `parent_data` by recapturing the parent's models during the replay instead. It isn't a clean win. Per-model tagging would mean de-batching the one-`execute_batch`-per-connection call that `fixture_cache_spec.rb` pins. The other option, stashing replayed models on the coder instance for `generate` to read back, swaps the explicit parameter for hidden state that depends on mount running inside generate's block. Both are worse than what's there, so the comment also records that the parameter is load-bearing.

## Change

Comments only, in two places: the merge site in `#generate` and the `execute_batch` tag in `#mount`. No behavior change. The existing "includes parent fixture model records when saving inherited fixtures" spec already covers the behavior.
