### PR TITLE
Authenticate release workflow to Cloudsmith via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: gem build fixture_kit.gemspec
 
       - name: Push to Cloudsmith
-        run: GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" gem push fixture_kit-*.gem --host https://ruby.cloudsmith.io/gusto/gusto
+        run: GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" gem push fixture_kit-*.gem --host https://cloudsmith.io/gusto/gusto
 
       - name: Upload gem to release
         continue-on-error: true  # May fail due to IP allow list restrictions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,20 @@ on:
 
 permissions:
   contents: write  # Required for uploading release assets
+  id-token: write  # Required to mint the OIDC token for Cloudsmith auth
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Authenticate with Cloudsmith via OIDC
+        uses: cloudsmith-io/cloudsmith-cli-action@v2
+        with:
+          oidc-namespace: "gusto"
+          oidc-service-slug: "gusto-cloudsmith-write-svc-01"
+          oidc-auth-only: "true"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -21,10 +29,8 @@ jobs:
       - name: Build gem
         run: gem build fixture_kit.gemspec
 
-      - name: Push to RubyGems
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        run: gem push fixture_kit-*.gem
+      - name: Push to Cloudsmith
+        run: GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}" gem push fixture_kit-*.gem --host https://ruby.cloudsmith.io/gusto/gusto
 
       - name: Upload gem to release
         continue-on-error: true  # May fail due to IP allow list restrictions


### PR DESCRIPTION
## What

Test PR for the Cloudsmith migration effort. Repoints the `gem push` step from RubyGems to Cloudsmith, using the same GitHub OIDC -> Cloudsmith token exchange pattern already merged and working in [Gusto/virtuous-pdf#452](https://github.com/Gusto/virtuous-pdf/pull/452).

## Changes

- Add `permissions: id-token: write` (required to mint the OIDC token).
- Add a step authenticating to Cloudsmith via `cloudsmith-io/cloudsmith-cli-action@v2` (`oidc-auth-only: "true"`), which exchanges the GitHub OIDC token for a short-lived Cloudsmith token and exports it as `CLOUDSMITH_API_KEY` — no static secret needed.
- Change "Push to RubyGems" -> "Push to Cloudsmith": `gem push fixture_kit-*.gem --host https://ruby.cloudsmith.io/gusto/gusto`, authenticated via `GEM_HOST_API_KEY="Bearer ${CLOUDSMITH_API_KEY}"` (Cloudsmith's documented format for RubyGems pushes).
- Left the old `secrets.RUBYGEMS_API_KEY` reference removed since it's no longer used; the secret itself can be cleaned up from repo settings separately once this is confirmed working.
- Left the "Upload gem to release" step untouched — unrelated to the registry migration.

## Why this repo first

Marked as a test case: this is a near-exact analog of the already-merged virtuous-pdf fix (plain `gem push`, no `bundle install` step to also repoint), so it's the lowest-risk way to confirm the pattern works before rolling it out to the rest of the RubyGems/npm/NuGet/Docker repos identified in the Cloudsmith migration audit.

**Opened as draft** — holding for a real release run (or manual dispatch, if you'd like me to add a `workflow_dispatch` trigger) to confirm the push actually succeeds against Cloudsmith before merging.