### PR TITLE
Add Repository#to_hash for splatting parent into expose

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -102,6 +102,15 @@ FixtureKit.define(extends: "project_management") do
 end
 ```
 
+`Repository` responds to `to_hash`, so `parent` can be splatted to re-expose all of the parent's records alongside new ones:
+
+```ruby
+FixtureKit.define(extends: "project_management") do
+  task = Task.create!(project: parent.project, assignee: parent.owner)
+  expose(**parent, task: task)
+end
+```
+
 ### Chained inheritance
 
 Inheritance can be chained — a child can extend a fixture that itself extends another:

--- a/lib/fixture_kit/repository.rb
+++ b/lib/fixture_kit/repository.rb
@@ -10,6 +10,10 @@ module FixtureKit
       define_readers
     end
 
+    def to_hash
+      @records.keys.to_h { |name| [name, fetch(name)] }
+    end
+
     private
 
     def define_readers

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe FixtureKit::Repository do
+  describe "#to_hash" do
+    it "materializes every exposed record keyed by name" do
+      alice = User.create!(name: "Alice", email: "alice-to-hash@example.com")
+      bob = User.create!(name: "Bob", email: "bob-to-hash@example.com")
+
+      repository = described_class.new(
+        alice: { User => alice.id },
+        bob: { User => bob.id }
+      )
+
+      expect(repository.to_hash).to eq(alice: alice, bob: bob)
+    end
+
+    it "materializes arrays of exposed records" do
+      alice = User.create!(name: "Alice", email: "alice-array@example.com")
+      bob = User.create!(name: "Bob", email: "bob-array@example.com")
+
+      repository = described_class.new(
+        users: [{ User => alice.id }, { User => bob.id }]
+      )
+
+      expect(repository.to_hash).to eq(users: [alice, bob])
+    end
+
+    it "uses symbol keys so it can be splatted into keyword arguments" do
+      alice = User.create!(name: "Alice", email: "alice-splat@example.com")
+      repository = described_class.new(owner: { User => alice.id })
+
+      collected = ->(**records) { records }
+
+      expect(collected.call(**repository)).to eq(owner: alice)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `FixtureKit::Repository#to_hash` so a child definition that `extends` another fixture can re-expose all of the parent's records alongside new ones:

```ruby
FixtureKit.define(extends: "project_management") do
  task = Task.create!(project: parent.project, assignee: parent.owner)
  expose(**parent, task: task)
end
```

Ruby's `**` invokes `to_hash` implicitly, so `parent` splats cleanly into the `expose(**records)` call.

## Why materialize instead of returning `@records`?

`@records` is a hash, but its *values* are serialized pointers (`{ User => 1 }`), not records. Those flow into `FileCache#serialize_exposed` when the child saves, which calls `.class`/`.id` expecting an AR record — a raw pointer hash raises `NoMethodError: undefined method 'id' for an instance of Hash`. `to_hash` reuses the existing `fetch` path to hand back the same shape `expose` normally receives (real, memoized records).

## Tests

New `spec/unit/repository_spec.rb` covers single records, arrays of records, and a direct proof that a `Repository` splats into a `**records` parameter with symbol keys.

## Docs

Added the `expose(**parent, ...)` example to `docs/reference.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYYP9N5Zkvdbx8rvJMRqic