### PR TITLE
Add on_register callback and bump to 0.18.0

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -264,6 +264,12 @@ Options are available via `attr_reader :options` in `FixtureKit::Adapter`.
 
 Register using configuration methods:
 
+`config.on_register { |event, scope| ... }`
+- Runs when a fixture is registered (declared), before any caching.
+- `scope` is the declaring context passed to `register`. For the RSpec adapter it is the
+  example group (`describe`/`context`) that declared the fixture, so
+  `scope.metadata[:file_path]` gives the originating spec file.
+
 `config.on_cache_save { |fixture| ... }`
 - Runs before cache save.
 
@@ -278,9 +284,9 @@ Register using configuration methods:
 - Runs after cache mount.
 - `duration` is elapsed seconds as `Float`.
 
-The `fixture` argument is a `FixtureKit::Event` instance. Methods:
-- `fixture.identifier` — String cache identifier (no `.json` suffix).
-- `fixture.path` — file path where the fixture definition block was defined.
+The first block argument (`fixture`/`event` above) is a `FixtureKit::Event` instance. Methods:
+- `event.identifier` — String cache identifier (no `.json` suffix).
+- `event.path` — file path where the fixture definition block was defined.
 
 Behavior:
 - Multiple callbacks per event supported.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -264,7 +264,7 @@ Options are available via `attr_reader :options` in `FixtureKit::Adapter`.
 
 Register using configuration methods:
 
-`config.on_register { |event, scope| ... }`
+`config.on_register { |fixture, scope| ... }`
 - Runs when a fixture is registered (declared), before any caching.
 - `scope` is the declaring context passed to `register`. For the RSpec adapter it is the
   example group (`describe`/`context`) that declared the fixture, so
@@ -284,9 +284,9 @@ Register using configuration methods:
 - Runs after cache mount.
 - `duration` is elapsed seconds as `Float`.
 
-The first block argument (`fixture`/`event` above) is a `FixtureKit::Event` instance. Methods:
-- `event.identifier` — String cache identifier (no `.json` suffix).
-- `event.path` — file path where the fixture definition block was defined.
+The `fixture` argument is a `FixtureKit::Event` instance. Methods:
+- `fixture.identifier` — String cache identifier (no `.json` suffix).
+- `fixture.path` — file path where the fixture definition block was defined.
 
 Behavior:
 - Multiple callbacks per event supported.

--- a/gemfiles/rails_8.0.gemfile.lock
+++ b/gemfiles/rails_8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixture_kit (0.17.1)
+    fixture_kit (0.18.0)
       activerecord (>= 8.0)
       activesupport (>= 8.0)
       benchmark
@@ -216,7 +216,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  fixture_kit (0.17.1)
+  fixture_kit (0.18.0)
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae

--- a/gemfiles/rails_8.1.gemfile.lock
+++ b/gemfiles/rails_8.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixture_kit (0.17.1)
+    fixture_kit (0.18.0)
       activerecord (>= 8.0)
       activesupport (>= 8.0)
       benchmark
@@ -217,7 +217,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  fixture_kit (0.17.1)
+  fixture_kit (0.18.0)
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae

--- a/lib/fixture_kit/callbacks.rb
+++ b/lib/fixture_kit/callbacks.rb
@@ -3,6 +3,7 @@
 module FixtureKit
   class Callbacks
     EVENTS = [
+      :register,
       :cache_save,
       :cache_saved,
       :cache_mount,

--- a/lib/fixture_kit/configuration.rb
+++ b/lib/fixture_kit/configuration.rb
@@ -26,6 +26,12 @@ module FixtureKit
       @adapter_options = options
     end
 
+    # Fires when a fixture is registered, before any caching. The block receives the
+    # Event and the declaring scope (the example group for the RSpec adapter).
+    def on_register(&block)
+      callbacks.register(:register, &block)
+    end
+
     def on_cache_save(&block)
       callbacks.register(:cache_save, &block)
     end

--- a/lib/fixture_kit/runner.rb
+++ b/lib/fixture_kit/runner.rb
@@ -16,7 +16,9 @@ module FixtureKit
     end
 
     def register(name_or_definition, scope)
-      registry.add(name_or_definition, scope)
+      fixture = registry.add(name_or_definition, scope)
+      configuration.callbacks.run(:register, Event.new(fixture), scope)
+      fixture
     end
 
     def start

--- a/lib/fixture_kit/version.rb
+++ b/lib/fixture_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FixtureKit
-  VERSION = "0.17.1"
+  VERSION = "0.18.0"
 end

--- a/spec/dummy/Gemfile.lock
+++ b/spec/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    fixture_kit (0.17.1)
+    fixture_kit (0.18.0)
       activerecord (>= 8.0)
       activesupport (>= 8.0)
       benchmark
@@ -216,7 +216,7 @@ CHECKSUMS
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   erb (6.0.1.1) sha256=ce5357460652a9a94667c5769eaffc551eea2b14a8531ac7c7b1d77b860758b9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  fixture_kit (0.17.1)
+  fixture_kit (0.18.0)
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -37,6 +37,28 @@ RSpec.describe FixtureKit::Configuration do
     end
   end
 
+  describe "#on_register" do
+    it "defaults to an empty callback list" do
+      expect(described_class.new.on_register).to eq([])
+    end
+
+    it "registers and runs callbacks in order with the event and scope" do
+      configuration = described_class.new
+      callback_one = spy("callback_one")
+      callback_two = spy("callback_two")
+      event = double("event")
+      scope = double("scope")
+
+      configuration.on_register { |e, s| callback_one.call(e, s) }
+      configuration.on_register { |e, s| callback_two.call(e, s) }
+
+      expect(callback_one).to receive(:call).with(event, scope).ordered
+      expect(callback_two).to receive(:call).with(event, scope).ordered
+
+      configuration.callbacks.run(:register, event, scope)
+    end
+  end
+
   describe "#on_cache_save" do
     it "defaults to an empty callback list" do
       expect(described_class.new.on_cache_save).to eq([])

--- a/spec/unit/fixture_runner_spec.rb
+++ b/spec/unit/fixture_runner_spec.rb
@@ -129,5 +129,21 @@ RSpec.describe FixtureKit::Runner do
 
       expect(registry).to have_received(:add).with(have_attributes(extends: "teams/basic"), scope)
     end
+
+    it "runs on_register callbacks with the fixture event and the declaring scope" do
+      runner = described_class.new
+      received_event = nil
+      received_scope = nil
+      runner.configuration.on_register do |event, declaring_scope|
+        received_event = event
+        received_scope = declaring_scope
+      end
+
+      runner.register(fixture_name, scope)
+
+      expect(received_event).to be_a(FixtureKit::Event)
+      expect(received_event.fixture).to eq(fixture)
+      expect(received_scope).to eq(scope)
+    end
   end
 end


### PR DESCRIPTION
## What

Adds a new `on_register` callback that fires when a fixture is **registered (declared)**, before any caching:

```ruby
config.on_register do |event, scope|
  # event: FixtureKit::Event (the declared fixture)
  # scope: the declaring context — for RSpec, the example group that called `fixture`
end
```

- New `:register` event in `Callbacks::EVENTS`, exposed via `Configuration#on_register`.
- Fired from `Runner#register` (the single registration entry point both the RSpec and Minitest adapters go through) as `run(:register, Event.new(fixture), scope)`.
- The `scope` rides alongside the `Event` as a second argument, mirroring how `duration` accompanies the Event for `on_cache_saved`/`on_cache_mounted`. `Event` itself is unchanged.
- Bumps the version to **0.18.0** (additive, backward compatible).
- Documents the callback in `docs/reference.md`.

## Why the scope is a separate argument (not read off the fixture)

The declaring scope is **not** derivable from the `Fixture`:

- A named fixture stores only its **name string** as `identifier`, not a scope.
- Named fixtures are **shared across scopes** — one `Fixture` instance can be declared in many groups — so `fixture → scope` isn't even a function (see the existing `spec/unit/fixture_registry_spec.rb` "reuses the same named fixture instance across different scopes").
- `definition.path` for a named fixture points at the fixture definition file (`spec/fixture_kit/<name>.rb`), not the declaring spec.

The scope is only known at the `register(name, scope)` call site, which is where the hook fires.

## Motivation

Lets tooling map a fixture declaration back to its originating spec file (`scope.metadata[:file_path]` for RSpec) at load time, without scanning `RSpec.world` or monkeypatching the DSL. First consumer: the Buildkite RSpec formatter, to flag which spec-file folds use FixtureKit.

## Tests

- `configuration_spec` — `on_register` registers/runs callbacks with the event and scope.
- `fixture_runner_spec` — `register` fires `on_register` with the fixture Event and declaring scope.
- Full suite green: **185 examples, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6ts71bokStreee58rP3or