### PR TITLE
Reuse one adapter harness class instead of one per generation

### DIFF
--- a/lib/fixture_kit/adapters/minitest_adapter.rb
+++ b/lib/fixture_kit/adapters/minitest_adapter.rb
@@ -7,15 +7,18 @@ require "active_support/inflector"
 module FixtureKit
   class MinitestAdapter < FixtureKit::Adapter
     TEST_NAME = "fixture kit cache pregeneration"
+    TEST_METHOD = :"test_#{TEST_NAME.tr(" ", "_")}"
 
     def execute(&block)
-      test_class = build_test_class
-      test_method = test_class.test(TEST_NAME) do
+      test = test_class.new(TEST_METHOD)
+      # Minitest runs a test by sending its name to the instance, so defining it
+      # here leaves the reused class untouched and the block dies with the test.
+      test.define_singleton_method(TEST_METHOD) do
         block.call(self)
         pass
       end
 
-      result = test_class.new(test_method).run
+      result = test.run
       return if result.passed?
 
       raise result.failures.first.error
@@ -27,8 +30,11 @@ module FixtureKit
 
     private
 
-    def build_test_class
-      Class.new(ActiveSupport::TestCase) do
+    # Reused rather than built per generation: including
+    # ActiveRecord::TestFixtures appends the class to ActiveSupport's
+    # :active_record_fixtures load hooks, and that never shrinks.
+    def test_class
+      @test_class ||= Class.new(ActiveSupport::TestCase) do
         ::Minitest::Runnable.runnables.delete(self)
         include(::ActiveRecord::TestFixtures)
       end

--- a/lib/fixture_kit/adapters/rspec_adapter.rb
+++ b/lib/fixture_kit/adapters/rspec_adapter.rb
@@ -7,12 +7,14 @@ module FixtureKit
     def execute(&block)
       previous_example = ::RSpec.current_example
       previous_scope = ::RSpec.current_scope
-      example_group = build_example_group
-      example = example_group.example { block.call(self) }
+      group = example_group
+      example = group.example { block.call(self) }
       succeeded =
         begin
-          example.run(example_group.new, ::RSpec::Core::NullReporter)
+          example.run(group.new, ::RSpec::Core::NullReporter)
         ensure
+          # The group is reused, and the example it holds retains this block.
+          group.examples.clear
           ::RSpec.current_example = previous_example
           ::RSpec.current_scope = previous_scope
         end
@@ -27,8 +29,11 @@ module FixtureKit
 
     private
 
-    def build_example_group
-      ::RSpec::Core::ExampleGroup.subclass(
+    # Reused rather than built per generation: rspec-rails includes
+    # ActiveRecord::TestFixtures into every group, which appends it to
+    # ActiveSupport's :active_record_fixtures load hooks, and that never shrinks.
+    def example_group
+      @example_group ||= ::RSpec::Core::ExampleGroup.subclass(
         ::RSpec::Core::ExampleGroup,
         "FixtureKit",
         [],

--- a/spec/unit/minitest_adapter_spec.rb
+++ b/spec/unit/minitest_adapter_spec.rb
@@ -16,24 +16,48 @@ RSpec.describe FixtureKit::MinitestAdapter do
 
       expect(captured_test_case_class).to be < ActiveSupport::TestCase
       expect(captured_test_case_class.included_modules).to include(ActiveRecord::TestFixtures)
-      expect(captured_test_case_class.public_instance_methods(false).map(&:to_s))
-        .to include("test_fixture_kit_cache_pregeneration")
     end
 
-    it "builds a fresh harness class for each execute on the same adapter instance" do
-      captured_test_case_classes = []
+    it "defines the pregeneration test method on the instance, not the harness class" do
+      harness_class = nil
+      defined_on_instance = nil
 
-      allow(Minitest::Runnable.runnables).to receive(:delete).and_wrap_original do |original, test_case_class|
-        captured_test_case_classes << test_case_class
-        original.call(test_case_class)
+      described_class.new.execute do |context|
+        harness_class = context.class
+        defined_on_instance = context.singleton_class
+          .instance_methods(false)
+          .include?(described_class::TEST_METHOD)
       end
 
-      adapter = described_class.new
-      adapter.execute { nil }
-      adapter.execute { nil }
+      expect(defined_on_instance).to be(true)
+      expect(harness_class.method_defined?(described_class::TEST_METHOD)).to be(false)
+    end
 
-      expect(captured_test_case_classes.size).to be >= 2
-      expect(captured_test_case_classes[-2]).not_to equal(captured_test_case_classes[-1])
+    it "reuses one harness class across executes on the same adapter instance" do
+      harness_classes = []
+      adapter = described_class.new
+
+      adapter.execute { |context| harness_classes << context.class }
+      adapter.execute { |context| harness_classes << context.class }
+
+      expect(harness_classes.size).to eq(2)
+      expect(harness_classes.first).to equal(harness_classes.last)
+    end
+
+    it "leaves no per-generation state on the reused harness class" do
+      adapter = described_class.new
+      harness_class = nil
+      adapter.execute { |context| harness_class = context.class }
+      snapshot = lambda do
+        [harness_class.instance_variables.sort, harness_class.public_instance_methods(false).sort]
+      end
+      baseline = snapshot.call
+
+      adapter.execute { nil }
+      expect { adapter.execute { raise "harness exploded" } }
+        .to raise_error(RuntimeError, "harness exploded")
+
+      expect(snapshot.call).to eq(baseline)
     end
 
     it "does not leak harness test cases into minitest runnables" do

--- a/spec/unit/rspec_adapter_spec.rb
+++ b/spec/unit/rspec_adapter_spec.rb
@@ -58,6 +58,36 @@ RSpec.describe FixtureKit::RSpecAdapter do
       end.to raise_error(RuntimeError, "harness exploded")
     end
 
+    it "reuses one harness example group across executes" do
+      harness_groups = []
+      adapter = described_class.new
+
+      adapter.execute { |context| harness_groups << context.class }
+      adapter.execute { |context| harness_groups << context.class }
+
+      expect(harness_groups.size).to eq(2)
+      expect(harness_groups.first).to equal(harness_groups.last)
+    end
+
+    it "assigns only one RSpec::ExampleGroups constant no matter how many times it runs" do
+      adapter = described_class.new
+      adapter.execute { nil }
+      constants_after_first = RSpec::ExampleGroups.constants.grep(/\AFixtureKit/).size
+
+      3.times { adapter.execute { nil } }
+
+      expect(RSpec::ExampleGroups.constants.grep(/\AFixtureKit/).size)
+        .to eq(constants_after_first)
+    end
+
+    it "does not retain the harness example after running" do
+      harness_group = nil
+
+      described_class.new.execute { |context| harness_group = context.class }
+
+      expect(harness_group.examples).to be_empty
+    end
+
     it "re-raises example.exception when execute returns false" do
       example_group = double("example_group")
       example = instance_double(RSpec::Core::Example)
@@ -66,6 +96,7 @@ RSpec.describe FixtureKit::RSpecAdapter do
 
       allow(::RSpec::Core::ExampleGroup).to receive(:subclass).and_return(example_group)
       allow(example_group).to receive(:example).and_return(example)
+      allow(example_group).to receive(:examples).and_return([])
       allow(example_group).to receive(:new).and_return(instance)
       allow(example).to receive(:run).with(instance, RSpec::Core::NullReporter).and_return(false)
       allow(example).to receive(:exception).and_return(failure)


### PR DESCRIPTION
Follow-up to #77. Independent of it — a second thing that accumulated for the whole run.

## Problem

To generate a fixture, the adapter has to run your fixture code inside something that behaves like a test, so transactions and Rails test setup work. Both adapters built a **throwaway test class for every generation** — and neither could ever be collected.

Two separate roots held onto them:

**1. An RSpec constant.** `ExampleGroup.subclass` → `set_it_up` → `ExampleGroups.assign_const(self)` (`example_group.rb:449`) `const_set`s the group under `RSpec::ExampleGroups`, so you accumulate `FixtureKit`, `FixtureKit_2`, `FixtureKit_3`… RSpec only clears those in `World#reset` ("Reset world to 'scratch' **before** running suite") and `RSpec.reset`, neither of which fires mid-run.

**2. A Rails global.** `rspec-rails/configuration.rb:88` includes `FixtureSupport` into *every* group with no metadata filter, and `MinitestAdapter` included `ActiveRecord::TestFixtures` directly. Either path runs:

```ruby
# active_record/test_fixtures.rb:41
ActiveSupport.run_load_hooks(:active_record_fixtures, self)
# active_support/lazy_load_hooks.rb:76
@loaded[name] << base      # never pruned
```

Removing the constants alone does **not** free the classes — I removed all of them, forced GC, and recounted: 40 alive before, 40 after. A heap dump traced the survivors to `ActiveSupport.@loaded[:active_record_fixtures]`.

These classes aren't cheap either: the RSpec harness ends up with 65 own instance methods (37 of them assertion delegators rspec-rails `define_method`s onto every group) across 30 ancestors, plus a `LetDefinitions` module, metadata hash, and singleton class.

## Fix

Since we don't own either registry — and one of them is private Rails internals — the fix is to stop creating classes to leak. Each adapter builds **one** harness lazily and reuses it.

The block that closes over the `Cache` is kept off the shared class:

- **RSpec** clears the group's `examples` after each run, since the `Example` holds the block.
- **Minitest** defines its test method on the *instance* rather than the class. `Minitest::Test#run` does `self.send self.name` (`test.rb:91`), so a singleton method is enough, and it goes away with the instance.

That leaves the Minitest harness class completely untouched by generation — nothing to define, remove, or clear. Worth noting what *isn't* available here: `ActiveSupport::Testing::Declarative#test` is just `define_method` plus a raise-on-redefinition guard, and Minitest's `runnable_methods` is pure reflection over `/^test_/` names. There's no registry to add to or remove from, so there was never anything to unregister.

## Impact

At 300 fixtures:

| | before | after |
|---|---|---|
| retained heap | 26.5 MB | 21.1 MB |
| live objects | 622,161 | 452,940 |
| allocations | 4,336,506 | 3,987,015 |
| harness classes retained all run | **301** | **1** |

The last row is the real signal: one per generation before, exactly one total after, regardless of suite size. Per-fixture retained growth drops ~43 KB → ~24 KB, at which point the remainder is RSpec's own per-example-group cost.

## Why reusing the harness is safe

Per-run state goes through the **instance**, not the class — `configure_example` uses `example.example_group_instance.singleton_class` (`configuration.rb:1582`), and `with_around_and_singleton_context_hooks` uses `example_group_instance.singleton_class` (`example.rb:509`). A fresh instance per generation means those die each run.

I snapshotted the RSpec group across three generations: ivars, own methods, ancestors, metadata keys, serialized metadata size, and every hook collection count were **identical**. Hooks *are* written to the group, but `process` subtracts hooks already present in `parent_groups` first, so it appends once and short-circuits after — idempotent by construction.

Global hook firing is identical reused vs. fresh: `before(:context)` 0, `after(:context)` 0, `before(:example)` 1 per generation, both ways.

I also checked `store_before_context_ivars`, which copies instance ivars onto a class-level hash — the one path that could carry fixture data onto the group. With four fixtures each setting a 500KB ivar: `before_context_ivars` is `{}` and 0 blobs survive. It runs against the instance's singleton, and `run_after_context_hooks` ends with `before_context_ivars.clear`.

After 5 real generations the harness has 30 ancestors — same as a pristine group — so `Definition#evaluate`'s `context.singleton_class.prepend` lands on the instance, not the class.

## Known behavior change

Reusing the harness means fixture code that **explicitly reaches `self.class`** now mutates a shared class instead of a per-generation one. Demonstrated:

```ruby
fixture do
  self.class.instance_variable_set(:@leaked, "w" * 300_000)
  self.class.define_method(:"sneaky_#{i}") { :hi }
end
# => @leaked persists; [:sneaky_0, :sneaky_1] accumulate
```

In practice this is unreachable from normal fixtures: a definition block runs at instance level via `instance_exec`, and any factory or library code it calls has its own `self`. Only a literal `self.class.…` written in a definition is affected. Nothing in this repo does that. Flagging it because it is a real reduction in isolation, not because I expect it to bite.

## Testing

- `bundle exec rspec` — 197 examples, 0 failures
- `FIXTURE_KIT_INTEGRATION_FRAMEWORK=minitest bundle exec rspec` — 197 examples, 0 failures
- Dummy app suites directly (multiple generations per process, incl. `extends` chains): minitest 21 runs / 67 assertions, RSpec 23 examples

New specs: harness reuse across executes, only one `RSpec::ExampleGroups` constant no matter how many runs, no retained example after running, the Minitest test method defined on the instance and not the class, and no per-generation state accumulating on the reused harness class across a success and a raise.

## Note for review

`ExampleGroup#examples` is marked `# @private` in rspec-core though it is a public method. There is no less-coupled way to drop the example while reusing the group; it is consistent with the existing deliberate use of `connection.__send__(:execute_batch, …)`, and there is an inline comment explaining why it is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQjkiuuGX2t3TSZKpzqpPv