### PR TITLE
Require an id when exposing a record, not persistence

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -80,9 +80,15 @@ end
 - Duplicate exposed names raise `FixtureKit::DuplicateNameError`.
 - Records are captured as class/id pairs at the moment `expose` is called, not
   at the end of the definition. The record objects themselves are not retained.
-- Exposing a record that is not persisted raises
-  `FixtureKit::UnpersistedRecordError`. This applies to records inside an
-  exposed collection as well, and to records that have been destroyed.
+- Exposing a record with no id raises `FixtureKit::UnpersistedRecordError`.
+  This applies to records inside an exposed collection as well.
+- Only the class and the id are stored, so an unsaved instance carrying the id
+  of a real row is a valid way to expose that row under a different model class
+  than the one that created it:
+
+  ```ruby
+  expose(address: Addresses::Db::Address.new(id: company_address.id))
+  ```
 
 Because capture happens when `expose` is called, expose a record only once it
 has been saved:

--- a/lib/fixture_kit/definition.rb
+++ b/lib/fixture_kit/definition.rb
@@ -40,9 +40,9 @@ module FixtureKit
     end
 
     def reference(name, record)
-      unless record.persisted?
+      if record.id.nil?
         raise FixtureKit::UnpersistedRecordError,
-          "cannot expose #{name.inspect}: the #{record.class} is not persisted. " \
+          "cannot expose #{name.inspect}: the #{record.class} has no id. " \
           "Exposed records are captured as class/id pairs when `expose` is called, " \
           "so save the record before exposing it."
       end

--- a/spec/unit/definition_spec.rb
+++ b/spec/unit/definition_spec.rb
@@ -101,17 +101,17 @@ RSpec.describe FixtureKit::Definition do
       expect(definition.exposed).to eq({ sedan: { Car => sedan.id } })
     end
 
-    it "raises when the record is not persisted" do
+    it "raises when the record has no id" do
       unsaved = User.new(name: "Alice", email: "alice-unsaved@example.com")
       definition = described_class.new { expose(alice: unsaved) }
 
       expect { definition.evaluate(Object.new) }.to raise_error(
         FixtureKit::UnpersistedRecordError,
-        /cannot expose :alice: the User is not persisted/
+        /cannot expose :alice: the User has no id/
       )
     end
 
-    it "raises when a record inside a collection is not persisted" do
+    it "raises when a record inside a collection has no id" do
       saved = User.create!(name: "Alice", email: "alice-mixed@example.com")
       unsaved = User.new(name: "Bob", email: "bob-mixed@example.com")
       definition = described_class.new { expose(users: [saved, unsaved]) }
@@ -122,13 +122,16 @@ RSpec.describe FixtureKit::Definition do
       )
     end
 
-    it "raises when the record has been destroyed" do
-      destroyed = User.create!(name: "Alice", email: "alice-destroyed@example.com")
-      destroyed.destroy!
-      definition = described_class.new { expose(alice: destroyed) }
+    # Only the class and the id are stored, so an unsaved instance carrying the
+    # id of a real row is a valid way to expose that row under a different
+    # model class than the one that created it.
+    it "accepts an unsaved instance that carries the id of a real row" do
+      alice = User.create!(name: "Alice", email: "alice-reference@example.com")
+      definition = described_class.new { expose(alice: User.new(id: alice.id)) }
 
-      expect { definition.evaluate(Object.new) }
-        .to raise_error(FixtureKit::UnpersistedRecordError)
+      definition.evaluate(Object.new)
+
+      expect(definition.exposed).to eq({ alice: { User => alice.id } })
     end
 
     it "allows an empty collection" do


### PR DESCRIPTION
Fixes a false positive in the guard added by #77, found by running against zenpayroll on CI ([zenpayroll#363546](https://github.com/Gusto/zenpayroll/pull/363546), [build 1660069](https://buildkite.com/gusto/zenpayroll/builds/1660069)).

## The failure

```
cannot expose :company_address_2: the Addresses::Db::Address is not persisted.
```

From `spec/fixture_kit/reporting_toolkit/fully_populated_payroll_custom_report.rb`:

```ruby
expose company:,
       employee_1:,
       company_address_2: Addresses.const_get(:Db)::Address.new(id: company_address_2.id)
```

That is not a mistake. `company_address_2` **is** created with `FactoryBot.create` a few lines earlier — the bare `Address.new(id:)` is a deliberate reference stub, used to expose that row under a different model class than the factory returns. Since `expose` only ever stores the class and the id, it worked fine before the guard.

## Fix

Check `record.id.nil?` rather than `record.persisted?`.

That still catches what the guard was added for — an unsaved record captured with a nil id and silently resolving to `nil` in tests — while accepting a reference that points at a real row. It's also consistent with how the value is used: `Repository#load_record` does `unscoped.find_by(id: …)`, so an id is the only thing a lookup needs.

The tradeoff: a hard-destroyed record (id present, row gone) now slips through and resolves to `nil` instead of raising. That's the narrower case, and distinguishing it from the soft-deleted records `unscoped` exists to support isn't reliable, so I'd rather not guess.

## Blast radius

One line across 159 fixture files in zenpayroll. I checked every failed job in the build — `company_address_2` is the only `UnpersistedRecordError`, and `.new(id:` appears in exactly one fixture.

## Testing

- `bundle exec rspec` — 197 examples, 0 failures
- `FIXTURE_KIT_INTEGRATION_FRAMEWORK=minitest bundle exec rspec` — 197 examples, 0 failures
- Reproduced the zp pattern in the dummy app first (it raised), confirmed it resolves to the real row after the change, and added it as a spec
- Dropped the destroyed-record spec, which no longer applies; kept the no-id specs for a single record and for a record inside a collection

## Note

The `Address.new(id: …)` stub is working around a missing feature — there's no first-class way to say "expose this row, looked up as class X." A `FixtureKit.reference(Klass, id)` helper would express that intent directly and stop the pattern looking like a bug. Out of scope here; worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQjkiuuGX2t3TSZKpzqpPv